### PR TITLE
Add state helper classes

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,7 @@ module.exports = {
     "coverageDirectory": "./coverage/",
     "collectCoverage": true,
     "coveragePathIgnorePatterns": [
-        "/node_modules/"
+        "/node_modules/",
+        "/test"
     ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@reside-ic/random": "^0.0.3"
+                "@reside-ic/random": "^0.0.3",
+                "ndarray": "^1.0.19"
             },
             "devDependencies": {
                 "@types/jest": "^28.1.4",
+                "@types/ndarray": "^1.0.11",
                 "@typescript-eslint/eslint-plugin": "^5.31.0",
                 "@typescript-eslint/parser": "^5.31.0",
                 "eslint": "^8.21.0",
@@ -1239,6 +1241,12 @@
             "version": "7.0.11",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+            "dev": true
+        },
+        "node_modules/@types/ndarray": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.11.tgz",
+            "integrity": "sha512-hOZVTN24zDHwCHaW7mF9n1vHJt83fZhNZ0YYRBwQGhA96yBWWDPTDDlqJatagHIOJB0a4xoNkNc+t/Cxd+6qUA==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -3182,11 +3190,21 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/iota-array": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+            "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA=="
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
+        },
+        "node_modules/is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "node_modules/is-core-module": {
             "version": "2.9.0",
@@ -4228,6 +4246,15 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
+        },
+        "node_modules/ndarray": {
+            "version": "1.0.19",
+            "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+            "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+            "dependencies": {
+                "iota-array": "^1.0.0",
+                "is-buffer": "^1.0.2"
+            }
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
@@ -6708,6 +6735,12 @@
             "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
+        "@types/ndarray": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@types/ndarray/-/ndarray-1.0.11.tgz",
+            "integrity": "sha512-hOZVTN24zDHwCHaW7mF9n1vHJt83fZhNZ0YYRBwQGhA96yBWWDPTDDlqJatagHIOJB0a4xoNkNc+t/Cxd+6qUA==",
+            "dev": true
+        },
         "@types/node": {
             "version": "18.0.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
@@ -8146,11 +8179,21 @@
             "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
             "dev": true
         },
+        "iota-array": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+            "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA=="
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-core-module": {
             "version": "2.9.0",
@@ -8945,6 +8988,15 @@
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
             "dev": true
+        },
+        "ndarray": {
+            "version": "1.0.19",
+            "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+            "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+            "requires": {
+                "iota-array": "^1.0.0",
+                "is-buffer": "^1.0.2"
+            }
         },
         "neo-async": {
             "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "homepage": "https://github.com/mrc-ide/dust-js#readme",
     "devDependencies": {
         "@types/jest": "^28.1.4",
+        "@types/ndarray": "^1.0.11",
         "@typescript-eslint/eslint-plugin": "^5.31.0",
         "@typescript-eslint/parser": "^5.31.0",
         "eslint": "^8.21.0",
@@ -35,6 +36,7 @@
         "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@reside-ic/random": "^0.0.3"
+        "@reside-ic/random": "^0.0.3",
+        "ndarray": "^1.0.19"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,5 @@ export {
     DustModelInfo,
     DustModelVariable
 } from "./model";
+export { dustState, DustState, VectorView } from "./state";
+export { dustStateTime, DustStateTime } from "./state-time";

--- a/src/particle.ts
+++ b/src/particle.ts
@@ -1,6 +1,7 @@
 import {Random} from "@reside-ic/random";
 
 import type {DustModel, DustModelConstructable, DustModelInfo} from "./model";
+import type {VectorView} from "./state";
 
 export class Particle {
     /** The step (in time) that the particle is currently at */
@@ -68,6 +69,29 @@ export class Particle {
      */
     public state(): readonly number[] {
         return this._y;
+    }
+
+    /**
+     * Copy particle state into a {@link VectorView} object, probably
+     * part of a {@link DustState} or {@link DustStateTime} object.
+     *
+     * @param index An index to use to restrict or order the copying
+     * of state. If non-`null`, then only the indicated states will be
+     * copied
+     *
+     * @param v The destination vector view to copy into
+     */
+    public copyState(index: number[] | null, v: VectorView): void {
+        const y = this._y;
+        if (index === null) {
+            for (let i = 0; i < y.length; ++i) {
+                v.set(i, y[i]);
+            }
+        } else {
+            for (let i = 0; i < index.length; ++i) {
+                v.set(i, y[index[i]]);
+            }
+        }
     }
 
     /**

--- a/src/particle.ts
+++ b/src/particle.ts
@@ -75,13 +75,13 @@ export class Particle {
      * Copy particle state into a {@link VectorView} object, probably
      * part of a {@link DustState} or {@link DustStateTime} object.
      *
+     * @param v The destination vector view to copy into
+     *
      * @param index An index to use to restrict or order the copying
      * of state. If non-`null`, then only the indicated states will be
      * copied
-     *
-     * @param v The destination vector view to copy into
      */
-    public copyState(index: number[] | null, v: VectorView): void {
+    public copyState(v: VectorView, index: number[] | null): void {
         const y = this._y;
         if (index === null) {
             for (let i = 0; i < y.length; ++i) {

--- a/src/state-time.ts
+++ b/src/state-time.ts
@@ -1,0 +1,112 @@
+import ndarray from "ndarray";
+
+import { copyVector, DustState, VectorView } from "./state";
+
+/**
+ * Create a new {@link DustStateTime} object, allocating the
+ * underlying storage
+ *
+ * @param nState Number of state variables
+ *
+ * @param nParticles Number of particles
+ *
+ * @param nTime Number of time steps
+ */
+export function dustStateTime(nState: number, nParticles: number,
+                              nTime: number) {
+    const data = ndarray(new Float64Array(nState * nParticles * nTime),
+                         [nTime, nParticles, nState]);
+    return new DustStateTime(data, nState, nParticles, nTime);
+}
+
+/**
+ * 3d-array-like object representing the state of a dust model at
+ * multiple points in time (vs a matrix-like object {@link
+ * DustState}. This object exists to simplify thinking about accessing
+ * different parts of the data, as primitives for doing this don't
+ * really exist in JavaScript. It also leaves us free to swap out the
+ * underling storage later (currently using `ndarray`)
+ */
+export class DustStateTime {
+    /** The underling state */
+    public readonly state: ndarray.NdArray;
+    /** The number of state elements per particle */
+    public readonly nState;
+    /** The number of particles */
+    public readonly nParticles;
+    /** The number of time steps */
+    public readonly nTime;
+
+    /**
+     * Construct a new object - generally prefer {@link dustStateTime}
+     * which also allocates the `data` correctly
+     *
+     * @param data The underlying data
+     * @param nState The number of state elements per particle
+     * @param nParticles The number of particles
+     * @param nTime The number of time steps
+     */
+    constructor(data: ndarray.NdArray, nState: number, nParticles: number,
+                nTime: number) {
+        this.nState = nState;
+        this.nParticles = nParticles;
+        this.nTime = nTime;
+        this.state = data;
+    }
+
+    /**
+     * Construct a view of a single time point - a {@link DustState}
+     * object - which can then be used to view or modify the state at
+     * this time point.
+     *
+     * @param iTime The index in time
+     */
+    public viewTime(iTime: number): DustState {
+        const data = this.state.pick(iTime, null, null);
+        return new DustState(data, this.nState, this.nParticles);
+    }
+
+    /**
+     * Construct a {@link VectorView} for a single particle at a
+     * single point in time. This can then be easily read from or
+     * written to.
+     * @param iParticle The index of the particle to fetch
+     * @param iTime The index of the time to fetch
+     */
+    public viewParticle(iParticle: number, iTime: number): VectorView {
+        return this.state.pick(iTime, iParticle, null);
+    }
+
+    /**
+     * Construct a {@link VectorView} for a single state, across all
+     * particles at a single point in time. This can then be easily
+     * read from or written to.
+     * @param iState The index of the state to fetch
+     * @param iTime The index of the time to fetch
+     */
+    public viewState(iState: number, iTime: number): VectorView {
+        return this.state.pick(iTime, null, iState);
+    }
+
+    /**
+     * Copy the state for a single vector at a single point in time
+     * into a plain JavaScript numeric array. This will then be
+     * decoupled from the underlying object
+     * @param iParticle The index of the particle to fetch
+     * @param iTime The index of the time to fetch
+     */
+    public getParticle(iParticle: number, iTime: number): number[] {
+        return copyVector(this.viewParticle(iParticle, iTime));
+    }
+
+    /**
+     * Copy a single state across all variables at a single point in
+     * time into a plain JavaScript numeric array. This will then be
+     * decoupled from the underlying object
+     * @param iState The index of the state to fetch
+     * @param iTime The index of the time to fetch
+     */
+    public getState(iState: number, iTime: number): number[] {
+        return copyVector(this.viewState(iState, iTime));
+    }
+}

--- a/src/state-time.ts
+++ b/src/state-time.ts
@@ -25,7 +25,7 @@ export function dustStateTime(nState: number, nParticles: number,
  * DustState}. This object exists to simplify thinking about accessing
  * different parts of the data, as primitives for doing this don't
  * really exist in JavaScript. It also leaves us free to swap out the
- * underling storage later (currently using `ndarray`)
+ * underlying storage later (currently using `ndarray`)
  */
 export class DustStateTime {
     /** The underlying state */

--- a/src/state-time.ts
+++ b/src/state-time.ts
@@ -28,7 +28,7 @@ export function dustStateTime(nState: number, nParticles: number,
  * underling storage later (currently using `ndarray`)
  */
 export class DustStateTime {
-    /** The underling state */
+    /** The underlying state */
     public readonly state: ndarray.NdArray;
     /** The number of state elements per particle */
     public readonly nState;

--- a/src/state-time.ts
+++ b/src/state-time.ts
@@ -100,9 +100,9 @@ export class DustStateTime {
     }
 
     /**
-     * Copy a single state across all variables at a single point in
-     * time into a plain JavaScript numeric array. This will then be
-     * decoupled from the underlying object
+     * Copy a single state variable across all particles at a single
+     * point in time into a plain JavaScript numeric array. This will
+     * then be decoupled from the underlying object
      * @param iState The index of the state to fetch
      * @param iTime The index of the time to fetch
      */

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,7 +1,3 @@
-// This file exists to abstract some of the array handling as it's a
-// general source of drama, and because I expect we'll swap out the
-// tensor backend for one that is typesafe in terms of dimensions. No
-// other file should directly import ndarray
 import ndarray from "ndarray";
 
 /**
@@ -16,23 +12,6 @@ export function dustState(nState: number, nParticles: number): DustState {
     const data = ndarray(new Float64Array(nState * nParticles),
                          [nParticles, nState]);
     return new DustState(data, nState, nParticles);
-}
-
-/**
- * Create a new {@link DustStateTime} object, allocating the
- * underlying storage
- *
- * @param nState Number of state variables
- *
- * @param nParticles Number of particles
- *
- * @param nTime Number of time steps
- */
-export function dustStateTime(nState: number, nParticles: number,
-                              nTime: number) {
-    const data = ndarray(new Float64Array(nState * nParticles * nTime),
-                         [nTime, nParticles, nState]);
-    return new DustStateTime(data, nState, nParticles, nTime);
 }
 
 /**
@@ -139,97 +118,6 @@ export class DustState {
     }
 }
 
-/**
- * 3d-array-like object representing the state of a dust model at
- * multiple points in time (vs a matrix-like object {@link
- * DustState}. This object exists to simplify thinking about accessing
- * different parts of the data, as primitives for doing this don't
- * really exist in JavaScript. It also leaves us free to swap out the
- * underling storage later (currently using `ndarray`)
- */
-export class DustStateTime {
-    /** The underling state */
-    public readonly state: ndarray.NdArray;
-    /** The number of state elements per particle */
-    public readonly nState;
-    /** The number of particles */
-    public readonly nParticles;
-    /** The number of time steps */
-    public readonly nTime;
-
-    /**
-     * Construct a new object - generally prefer {@link dustStateTime}
-     * which also allocates the `data` correctly
-     *
-     * @param data The underlying data
-     * @param nState The number of state elements per particle
-     * @param nParticles The number of particles
-     * @param nTime The number of time steps
-     */
-    constructor(data: ndarray.NdArray, nState: number, nParticles: number,
-                nTime: number) {
-        this.nState = nState;
-        this.nParticles = nParticles;
-        this.nTime = nTime;
-        this.state = data;
-    }
-
-    /**
-     * Construct a view of a single time point - a {@link DustState}
-     * object - which can then be used to view or modify the state at
-     * this time point.
-     *
-     * @param iTime The index in time
-     */
-    public viewTime(iTime: number): DustState {
-        const data = this.state.pick(iTime, null, null);
-        return new DustState(data, this.nState, this.nParticles);
-    }
-
-    /**
-     * Construct a {@link VectorView} for a single particle at a
-     * single point in time. This can then be easily read from or
-     * written to.
-     * @param iParticle The index of the particle to fetch
-     * @param iTime The index of the time to fetch
-     */
-    public viewParticle(iParticle: number, iTime: number): VectorView {
-        return this.state.pick(iTime, iParticle, null);
-    }
-
-    /**
-     * Construct a {@link VectorView} for a single state, across all
-     * particles at a single point in time. This can then be easily
-     * read from or written to.
-     * @param iState The index of the state to fetch
-     * @param iTime The index of the time to fetch
-     */
-    public viewState(iState: number, iTime: number): VectorView {
-        return this.state.pick(iTime, null, iState);
-    }
-
-    /**
-     * Copy the state for a single vector at a single point in time
-     * into a plain JavaScript numeric array. This will then be
-     * decoupled from the underlying object
-     * @param iParticle The index of the particle to fetch
-     * @param iTime The index of the time to fetch
-     */
-    public getParticle(iParticle: number, iTime: number): number[] {
-        return copyVector(this.viewParticle(iParticle, iTime));
-    }
-
-    /**
-     * Copy a single state across all variables at a single point in
-     * time into a plain JavaScript numeric array. This will then be
-     * decoupled from the underlying object
-     * @param iState The index of the state to fetch
-     * @param iTime The index of the time to fetch
-     */
-    public getState(iState: number, iTime: number): number[] {
-        return copyVector(this.viewState(iState, iTime));
-    }
-}
 
 export function copyVector(src: VectorView): number[] {
     const len = src.shape[0];

--- a/src/state.ts
+++ b/src/state.ts
@@ -16,7 +16,10 @@ export function dustState(nState: number, nParticles: number): DustState {
 
 /**
  * A one dimensional (slice) out of a {@link DustState} or {@link
- * DustStateTime} object
+ * DustStateTime} object. This is not really a new type, but just a
+ * restriction on the existing `ndarray.NdArray` type that means that
+ * TypeScript will expect exactly one index when using `get` and
+ * `set`, as `ndarray` does not have a vector type.
  */
 export interface VectorView {
     /** An array of length 1 containing the vector length */
@@ -107,7 +110,8 @@ export class DustState {
     /**
      * Create a matrix of particle states. The `i`th element of the
      * returned matrix is the state of the `i`th particle, itself a
-     * vector of length `nState`
+     * vector of length `nState`. This is a copy of the underlying
+     * data, decoupled from the state.
      */
     public asMatrix(): number[][] {
         const ret = [];

--- a/src/state.ts
+++ b/src/state.ts
@@ -107,7 +107,7 @@ export class DustState {
     /**
      * Create a matrix of particle states. The `i`th element of the
      * returned matrix is the state of the `i`th particle, itself a
-     * vector of lenth `nState`
+     * vector of length `nState`
      */
     public asMatrix(): number[][] {
         const ret = [];

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,0 +1,241 @@
+// This file exists to abstract some of the array handling as it's a
+// general source of drama, and because I expect we'll swap out the
+// tensor backend for one that is typesafe in terms of dimensions. No
+// other file should directly import ndarray
+import ndarray from "ndarray";
+
+/**
+ * Create a new {@link DustState} object, allocating the underlying
+ * storage
+ *
+ * @param nState Number of state variables
+ *
+ * @param nParticles Number of particles
+ */
+export function dustState(nState: number, nParticles: number): DustState {
+    const data = ndarray(new Float64Array(nState * nParticles),
+                         [nParticles, nState]);
+    return new DustState(data, nState, nParticles);
+}
+
+/**
+ * Create a new {@link DustStateTime} object, allocating the
+ * underlying storage
+ *
+ * @param nState Number of state variables
+ *
+ * @param nParticles Number of particles
+ *
+ * @param nTime Number of time steps
+ */
+export function dustStateTime(nState: number, nParticles: number,
+                              nTime: number) {
+    const data = ndarray(new Float64Array(nState * nParticles * nTime),
+                         [nTime, nParticles, nState]);
+    return new DustStateTime(data, nState, nParticles, nTime);
+}
+
+/**
+ * A one dimensional (slice) out of a {@link DustState} or {@link
+ * DustStateTime} object
+ */
+export interface VectorView {
+    /** An array of length 1 containing the vector length */
+    shape: number[];
+    /**
+     * Get the ith value
+     * @param i Index to fetch
+     */
+    get(i: number): number;
+    /**
+     * Set the ith value, modifying the underlying object as well as
+     * the view.
+     *
+     * @param i Index to set
+     * @param value The value to replace into the vector
+     */
+    set(i: number, value: number): void;
+}
+
+/**
+ * Matrix-like object representing the state of a dust model at a
+ * single point in time (vs a 3d-array like object {@link
+ * DustStateTime}. This object exists to simplify thinking about
+ * accessing different parts of the data, as primitives for doing this
+ * don't really exist in JavaScript. It also leaves us free to swap
+ * out the underling storage later (currently using `ndarray`)
+ */
+export class DustState {
+    /** The underling state */
+    public readonly state: ndarray.NdArray;
+    /** The number of state elements per particle */
+    public readonly nState;
+    /** The number of particles */
+    public readonly nParticles;
+
+    /**
+     * Construct a new object - generally prefer {@link dustState}
+     * which also allocates the `data` correctly
+     *
+     * @param data The underlying data
+     * @param nState The number of state elements per particle
+     * @param nParticles The number of particles
+     */
+    constructor(data: ndarray.NdArray, nState: number, nParticles: number) {
+        this.nState = nState;
+        this.nParticles = nParticles;
+        this.state = data;
+    }
+
+    /**
+     * Construct a {@link VectorView} for a single particle. This can
+     * then be easily read from or written to.
+     * @param iParticle The index of the particle to fetch
+     */
+    public viewParticle(iParticle: number): VectorView {
+        return this.state.pick(iParticle, null);
+    }
+
+    /**
+     * Construct a {@link VectorView} for a single state, across all
+     * particles. This can then be easily read from or written to.
+     * @param iState The index of the state to fetch
+     */
+    public viewState(iState: number): VectorView {
+        return this.state.pick(null, iState);
+    }
+
+    /**
+     * Copy the state for a single vector into a plain JavaScript
+     * numeric array. This will then be decoupled from the underlying
+     * object
+     * @param iParticle The index of the particle to fetch
+     */
+    public getParticle(iParticle: number): number[] {
+        return copyVector(this.viewParticle(iParticle));
+    }
+
+    /**
+     * Copy a single state across all variables into a plain
+     * JavaScript numeric array. This will then be decoupled from the
+     * underlying object
+     * @param iState The index of the state to fetch
+     */
+    public getState(iState: number): number[] {
+        return copyVector(this.viewState(iState));
+    }
+
+    /**
+     * Create a matrix of particle states. The `i`th element of the
+     * returned matrix is the state of the `i`th particle, itself a
+     * vector of lenth `nState`
+     */
+    public asMatrix(): number[][] {
+        const ret = [];
+        for (let i = 0; i < this.nParticles; ++i) {
+            ret.push(this.getParticle(i));
+        }
+        return ret;
+    }
+}
+
+/**
+ * 3d-array-like object representing the state of a dust model at
+ * multiple points in time (vs a matrix-like object {@link
+ * DustState}. This object exists to simplify thinking about accessing
+ * different parts of the data, as primitives for doing this don't
+ * really exist in JavaScript. It also leaves us free to swap out the
+ * underling storage later (currently using `ndarray`)
+ */
+export class DustStateTime {
+    /** The underling state */
+    public readonly state: ndarray.NdArray;
+    /** The number of state elements per particle */
+    public readonly nState;
+    /** The number of particles */
+    public readonly nParticles;
+    /** The number of time steps */
+    public readonly nTime;
+
+    /**
+     * Construct a new object - generally prefer {@link dustStateTime}
+     * which also allocates the `data` correctly
+     *
+     * @param data The underlying data
+     * @param nState The number of state elements per particle
+     * @param nParticles The number of particles
+     * @param nTime The number of time steps
+     */
+    constructor(data: ndarray.NdArray, nState: number, nParticles: number,
+                nTime: number) {
+        this.nState = nState;
+        this.nParticles = nParticles;
+        this.nTime = nTime;
+        this.state = data;
+    }
+
+    /**
+     * Construct a view of a single time point - a {@link DustState}
+     * object - which can then be used to view or modify the state at
+     * this time point.
+     *
+     * @param iTime The index in time
+     */
+    public viewTime(iTime: number): DustState {
+        const data = this.state.pick(iTime, null, null);
+        return new DustState(data, this.nState, this.nParticles);
+    }
+
+    /**
+     * Construct a {@link VectorView} for a single particle at a
+     * single point in time. This can then be easily read from or
+     * written to.
+     * @param iParticle The index of the particle to fetch
+     * @param iTime The index of the time to fetch
+     */
+    public viewParticle(iParticle: number, iTime: number): VectorView {
+        return this.state.pick(iTime, iParticle, null);
+    }
+
+    /**
+     * Construct a {@link VectorView} for a single state, across all
+     * particles at a single point in time. This can then be easily
+     * read from or written to.
+     * @param iState The index of the state to fetch
+     * @param iTime The index of the time to fetch
+     */
+    public viewState(iState: number, iTime: number): VectorView {
+        return this.state.pick(iTime, null, iState);
+    }
+
+    /**
+     * Copy the state for a single vector at a single point in time
+     * into a plain JavaScript numeric array. This will then be
+     * decoupled from the underlying object
+     * @param iParticle The index of the particle to fetch
+     * @param iTime The index of the time to fetch
+     */
+    public getParticle(iParticle: number, iTime: number): number[] {
+        return copyVector(this.viewParticle(iParticle, iTime));
+    }
+
+    /**
+     * Copy a single state across all variables at a single point in
+     * time into a plain JavaScript numeric array. This will then be
+     * decoupled from the underlying object
+     * @param iState The index of the state to fetch
+     * @param iTime The index of the time to fetch
+     */
+    public getState(iState: number, iTime: number): number[] {
+        return copyVector(this.viewState(iState, iTime));
+    }
+}
+
+export function copyVector(src: VectorView): number[] {
+    const len = src.shape[0];
+    const dst = Array(len);
+    for (let i = 0; i < len; ++i) {
+        dst[i] = src.get(i);
+    }
+    return dst;
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,10 +1,23 @@
+import ndarray from "ndarray";
 import { dustState } from "../src/state";
+import { dustStateTime } from "../src/state-time";
 
 export function filledDustState(nState: number, nParticles: number) {
     const state = dustState(nState, nParticles);
-    const d = state.state.data as Float64Array;
-    for (let i = 0; i < nState * nParticles; ++i) {
+    fillStateWithSequence(state.state);
+    return state;
+}
+
+export function filledDustStateTime(nState: number, nParticles:
+                                    number, nTime: number) {
+    const state = dustStateTime(nState, nParticles, nTime);
+    fillStateWithSequence(state.state);
+    return state;
+}
+
+function fillStateWithSequence(state: ndarray.NdArray) {
+    const d = state.data as Float64Array;
+    for (let i = 0; i < d.length; ++i) {
         d[i] = i;
     }
-    return state;
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,0 +1,10 @@
+import { dustState } from "../src/state";
+
+export function filledDustState(nState: number, nParticles: number) {
+    const state = dustState(nState, nParticles);
+    const d = state.state.data as Float64Array;
+    for (let i = 0; i < nState * nParticles; ++i) {
+        d[i] = i;
+    }
+    return state;
+}

--- a/test/particle.test.ts
+++ b/test/particle.test.ts
@@ -76,7 +76,7 @@ describe("Can create a particle", () => {
         const pars = {n, sd: 1};
         const p = new Particle(new models.Walk(base, pars), 0);
         p.setState([2, 3, 4, 5, 6]);
-        // Copy the full state into the second particle
+        // Copy the indexed state into the second particle
         p.copyState(index, state.viewParticle(1));
         expect(state.getParticle(0)).toEqual([0, 0]);
         expect(state.getParticle(1)).toEqual([3, 5]);

--- a/test/particle.test.ts
+++ b/test/particle.test.ts
@@ -64,7 +64,7 @@ describe("Can create a particle", () => {
         const p = new Particle(new models.Walk(base, pars), 0);
         p.setState([2, 3, 4, 5, 6]);
         // Copy the full state into the second particle
-        p.copyState(null, state.viewParticle(1));
+        p.copyState(state.viewParticle(1), null);
         expect(state.getParticle(0)).toEqual([0, 0, 0, 0, 0]);
         expect(state.getParticle(1)).toEqual([2, 3, 4, 5, 6]);
     });
@@ -77,7 +77,7 @@ describe("Can create a particle", () => {
         const p = new Particle(new models.Walk(base, pars), 0);
         p.setState([2, 3, 4, 5, 6]);
         // Copy the indexed state into the second particle
-        p.copyState(index, state.viewParticle(1));
+        p.copyState(state.viewParticle(1), index);
         expect(state.getParticle(0)).toEqual([0, 0]);
         expect(state.getParticle(1)).toEqual([3, 5]);
     });

--- a/test/particle.test.ts
+++ b/test/particle.test.ts
@@ -2,6 +2,7 @@ import { Random, RngStateBuiltin, RngStateObserved } from "@reside-ic/random";
 
 import { base } from "../src/base";
 import { Particle } from "../src/particle";
+import { dustState } from "../src/state";
 
 import * as models from "./models";
 
@@ -55,4 +56,29 @@ describe("Can create a particle", () => {
         expect(p.info()).toEqual(
             [{dim: [1], length: 1, name: "x"}]);
     })
+
+    it("Can copy state into a vector view", () => {
+        const n = 5;
+        const state = dustState(n, 3);
+        const pars = {n, sd: 1};
+        const p = new Particle(new models.Walk(base, pars), 0);
+        p.setState([2, 3, 4, 5, 6]);
+        // Copy the full state into the second particle
+        p.copyState(null, state.viewParticle(1));
+        expect(state.getParticle(0)).toEqual([0, 0, 0, 0, 0]);
+        expect(state.getParticle(1)).toEqual([2, 3, 4, 5, 6]);
+    });
+
+    it("Can copy partial into a vector view", () => {
+        const n = 5;
+        const index = [1, 3];
+        const state = dustState(index.length, 3);
+        const pars = {n, sd: 1};
+        const p = new Particle(new models.Walk(base, pars), 0);
+        p.setState([2, 3, 4, 5, 6]);
+        // Copy the full state into the second particle
+        p.copyState(index, state.viewParticle(1));
+        expect(state.getParticle(0)).toEqual([0, 0]);
+        expect(state.getParticle(1)).toEqual([3, 5]);
+    });
 });

--- a/test/state-time.test.ts
+++ b/test/state-time.test.ts
@@ -1,0 +1,13 @@
+import { dustStateTime } from "../src/state-time";
+
+describe("dust state at multiple time points", () => {
+    it("can be constructed", () => {
+        const nState = 5;
+        const nParticles = 7;
+        const nTime = 11;
+        const state = dustStateTime(nState, nParticles, nTime);
+        expect(state.nState).toBe(nState);
+        expect(state.nParticles).toBe(nParticles);
+        expect(state.nTime).toBe(nTime);
+    });
+});

--- a/test/state-time.test.ts
+++ b/test/state-time.test.ts
@@ -27,6 +27,17 @@ describe("dust state at multiple time points", () => {
         const state = filledDustStateTime(nState, nParticles, nTime);
         const t0 = state.viewTime(0);
         const t5 = state.viewTime(5);
+        expect(state.getParticle(0, 0)).toEqual(t0.getParticle(0));
+        expect(state.getParticle(3, 0)).toEqual(t0.getParticle(3));
+        expect(state.getParticle(0, 5)).toEqual(t5.getParticle(0));
+        expect(state.getParticle(3, 5)).toEqual(t5.getParticle(3));
+    });
+
+    it("can extract a state at a specific time", () => {
+        // Similar to above, but using getState, not getParticle
+        const state = filledDustStateTime(nState, nParticles, nTime);
+        const t0 = state.viewTime(0);
+        const t5 = state.viewTime(5);
         expect(state.getState(0, 0)).toEqual(t0.getState(0));
         expect(state.getState(3, 0)).toEqual(t0.getState(3));
         expect(state.getState(0, 5)).toEqual(t5.getState(0));

--- a/test/state-time.test.ts
+++ b/test/state-time.test.ts
@@ -1,13 +1,45 @@
 import { dustStateTime } from "../src/state-time";
 
+import { filledDustStateTime } from "./helpers";
+
 describe("dust state at multiple time points", () => {
+    const nState = 5;
+    const nParticles = 7;
+    const nTime = 11;
     it("can be constructed", () => {
-        const nState = 5;
-        const nParticles = 7;
-        const nTime = 11;
         const state = dustStateTime(nState, nParticles, nTime);
         expect(state.nState).toBe(nState);
         expect(state.nParticles).toBe(nParticles);
         expect(state.nTime).toBe(nTime);
+    });
+
+    it("can extract a time view", () => {
+        const state = filledDustStateTime(nState, nParticles, nTime);
+        const t0 = state.viewTime(0);
+        expect(t0.getParticle(0)).toEqual([0, 1, 2, 3, 4]);
+        expect(t0.getParticle(3)).toEqual([15, 16, 17, 18, 19]);
+        const t5 = state.viewTime(5);
+        expect(t5.getParticle(0)).toEqual([175, 176, 177, 178, 179]);
+        expect(t5.getParticle(3)).toEqual([190, 191, 192, 193, 194]);
+    });
+
+    it("can extract a particle at a specific time", () => {
+        const state = filledDustStateTime(nState, nParticles, nTime);
+        const t0 = state.viewTime(0);
+        const t5 = state.viewTime(5);
+        expect(state.getParticle(0, 0)).toEqual(t0.getParticle(0));
+        expect(state.getParticle(3, 0)).toEqual(t0.getParticle(3));
+        expect(state.getParticle(0, 5)).toEqual(t5.getParticle(0));
+        expect(state.getParticle(3, 5)).toEqual(t5.getParticle(3));
+    });
+
+    it("can extract a particle at a specific time", () => {
+        const state = filledDustStateTime(nState, nParticles, nTime);
+        const t0 = state.viewTime(0);
+        const t5 = state.viewTime(5);
+        expect(state.getState(0, 0)).toEqual(t0.getState(0));
+        expect(state.getState(3, 0)).toEqual(t0.getState(3));
+        expect(state.getState(0, 5)).toEqual(t5.getState(0));
+        expect(state.getState(3, 5)).toEqual(t5.getState(3));
     });
 });

--- a/test/state-time.test.ts
+++ b/test/state-time.test.ts
@@ -27,16 +27,6 @@ describe("dust state at multiple time points", () => {
         const state = filledDustStateTime(nState, nParticles, nTime);
         const t0 = state.viewTime(0);
         const t5 = state.viewTime(5);
-        expect(state.getParticle(0, 0)).toEqual(t0.getParticle(0));
-        expect(state.getParticle(3, 0)).toEqual(t0.getParticle(3));
-        expect(state.getParticle(0, 5)).toEqual(t5.getParticle(0));
-        expect(state.getParticle(3, 5)).toEqual(t5.getParticle(3));
-    });
-
-    it("can extract a particle at a specific time", () => {
-        const state = filledDustStateTime(nState, nParticles, nTime);
-        const t0 = state.viewTime(0);
-        const t5 = state.viewTime(5);
         expect(state.getState(0, 0)).toEqual(t0.getState(0));
         expect(state.getState(3, 0)).toEqual(t0.getState(3));
         expect(state.getState(0, 5)).toEqual(t5.getState(0));

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -13,7 +13,7 @@ describe("dust state at a single time point", () => {
         expect(state.nParticles).toBe(nParticles);
     });
 
-    it("can extract a view of a particle", () => {
+    it("can extract a single particle", () => {
         const state = filledDustState(nState, nParticles);
         const p0 = state.viewParticle(0);
         expect(p0.get(0)).toBe(0);
@@ -26,7 +26,7 @@ describe("dust state at a single time point", () => {
         expect(state.getParticle(3)).toEqual([15, 16, 17, 18, 19]);
     });
 
-    it("can extract a view of a state", () => {
+    it("can extract a state across particles", () => {
         const state = filledDustState(nState, nParticles);
         const p0 = state.viewState(0);
         expect(p0.get(0)).toBe(0);
@@ -46,4 +46,13 @@ describe("dust state at a single time point", () => {
         expect(m[0]).toEqual(state.getParticle(0));
         expect(m[3]).toEqual(state.getParticle(3));
     });
+
+    it("can mutate extracted particle state", () => {
+        const state = filledDustState(nState, nParticles);
+        const p = state.viewParticle(3);
+        for (let i = 0; i < nState; ++i) {
+            p.set(i, -i);
+        }
+        expect(state.getParticle(3)).toEqual([-0, -1, -2, -3, -4]);
+    })
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,6 +1,8 @@
-import { dustState } from "../src/state";
-import { dustStateTime } from "../src/state-time";
+import ndarray from "ndarray";
 
+import { dustState } from "../src/state";
+
+import { filledDustState } from "./helpers";
 
 describe("dust state at a single time point", () => {
     const nState = 5;
@@ -10,16 +12,38 @@ describe("dust state at a single time point", () => {
         expect(state.nState).toBe(nState);
         expect(state.nParticles).toBe(nParticles);
     });
-});
 
-describe("dust state at multiple time points", () => {
-    it("can be constructed", () => {
-        const nState = 5;
-        const nParticles = 7;
-        const nTime = 11;
-        const state = dustStateTime(nState, nParticles, nTime);
-        expect(state.nState).toBe(nState);
-        expect(state.nParticles).toBe(nParticles);
-        expect(state.nTime).toBe(nTime);
+    it("can extract a view of a particle", () => {
+        const state = filledDustState(nState, nParticles);
+        const p0 = state.viewParticle(0);
+        expect(p0.get(0)).toBe(0);
+        expect(p0.get(4)).toBe(4);
+        const p3 = state.viewParticle(3);
+        expect(p3.get(0)).toBe(15);
+        expect(p3.get(4)).toBe(19);
+
+        expect(state.getParticle(0)).toEqual([0, 1, 2, 3, 4]);
+        expect(state.getParticle(3)).toEqual([15, 16, 17, 18, 19]);
+    });
+
+    it("can extract a view of a state", () => {
+        const state = filledDustState(nState, nParticles);
+        const p0 = state.viewState(0);
+        expect(p0.get(0)).toBe(0);
+        expect(p0.get(4)).toBe(20);
+        const p3 = state.viewState(3);
+        expect(p3.get(0)).toBe(3);
+        expect(p3.get(4)).toBe(23);
+
+        expect(state.getState(0)).toEqual([0, 5, 10, 15, 20, 25, 30]);
+        expect(state.getState(3)).toEqual([3, 8, 13, 18, 23, 28, 33]);
+    });
+
+    it("can extract the state as a matrix", () => {
+        const state = filledDustState(nState, nParticles);
+        const m = state.asMatrix();
+        expect(m.length).toBe(nParticles);
+        expect(m[0]).toEqual(state.getParticle(0));
+        expect(m[3]).toEqual(state.getParticle(3));
     });
 });

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,0 +1,23 @@
+import { dustState, dustStateTime } from "../src/state";
+
+describe("dust state at a single time point", () => {
+    const nState = 5;
+    const nParticles = 7;
+    it("can be constructed", () => {
+        const state = dustState(nState, nParticles);
+        expect(state.nState).toBe(nState);
+        expect(state.nParticles).toBe(nParticles);
+    });
+});
+
+describe("dust state at multiple time points", () => {
+    it("can be constructed", () => {
+        const nState = 5;
+        const nParticles = 7;
+        const nTime = 11;
+        const state = dustStateTime(nState, nParticles, nTime);
+        expect(state.nState).toBe(nState);
+        expect(state.nParticles).toBe(nParticles);
+        expect(state.nTime).toBe(nTime);
+    });
+});

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -47,7 +47,7 @@ describe("dust state at a single time point", () => {
         expect(m[3]).toEqual(state.getParticle(3));
     });
 
-    it("can mutate extracted particle state", () => {
+    it("can mutate particle state via a view", () => {
         const state = filledDustState(nState, nParticles);
         const p = state.viewParticle(3);
         for (let i = 0; i < nState; ++i) {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,4 +1,6 @@
-import { dustState, dustStateTime } from "../src/state";
+import { dustState } from "../src/state";
+import { dustStateTime } from "../src/state-time";
+
 
 describe("dust state at a single time point", () => {
     const nState = 5;


### PR DESCRIPTION
This PR adds some multidimensional array classes to help with working with the sort of data that dust is going to produce. I'm using the ndarray package for this, which has an ok, but not great interface. One limitation is that you can't have type-safe ranks (so a multidimensional 2d and 3d array appear the same type). I've created a couple of wrapper classes around this (DustState and DustStateTime) which mean we can reason much more about things, but also mean that we get much more reasonable accesses that reflect what we really want to do (give me the contents of some particle at some time, rather than incomprehensible  and error prone accesses).

This will be be less abstract after the next PR which actually implements the Dust object and uses this, but this part took much longer to get right!