### PR TITLE
Add main dust class

### DIFF
--- a/src/dust.ts
+++ b/src/dust.ts
@@ -1,0 +1,196 @@
+import { Random, RngState } from "@reside-ic/random";
+
+import { base } from "./base";
+import type { DustModel, DustModelInfo, DustModelConstructable } from "./model";
+import { Pars } from "./pars";
+import { Particle } from "./particle";
+import { DustState, dustState } from "./state";
+import { DustStateTime, dustStateTime } from "./state-time";
+
+/**
+ * Dust models
+ */
+export class Dust {
+    private readonly _Model: DustModelConstructable;
+    private readonly _particles: Particle[];
+    private readonly _random: Random;
+
+    /**
+     * @param Model A constructor for the model to use in the simulation
+     *
+     * @param pars Initial parameters to use with the model
+     *
+     * @param nParticles Number of particles to use in the simulation
+     * - can't be changed after construction.
+     *
+     * @param step Initial step
+     *
+     * @param random The random state
+     */
+    constructor(Model: DustModelConstructable, pars: Pars, nParticles: number,
+                step: number, random: Random) {
+        if (nParticles <= 0) {
+            throw Error("Expected at least one particle");
+        }
+        this._Model = Model;
+        this._particles = [];
+        this._random = random;
+
+        // NOTE: Here, we construct the model just once per dust
+        // object and then use exactly the same model object
+        // (including temporary internal storage) across all particles
+        // in object. This is in contrast with the approach taken in
+        // the C++ code where we kept separate copies so that they
+        // could be run in parallel. If we parallelise this with web
+        // workers we might need to revisit this approach, but the API
+        // there looks nothing like OpenMP and this would probably
+        // still be ok, once per worker.
+        const model = new Model(base, pars);
+        for (let i = 0; i < nParticles; ++i) {
+            this._particles.push(new Particle(model, step));
+        }
+    }
+
+    /**
+     * Returns the number of state elements per particle
+     */
+    public nState(): number {
+        return this._particles[0].size;
+    }
+
+    /**
+     * Returns the number of particles
+     */
+    public nParticles(): number {
+        return this._particles.length;
+    }
+
+    /**
+     * The current step
+     */
+    public step(): number {
+        return this._particles[0].step;
+    }
+
+    /**
+     * Returns information about how the state is packed. This is
+     * useful for computing indexes and extracting state.
+     */
+    public info(): DustModelInfo {
+        return this._particles[0].info();
+    }
+
+    /**
+     * Set new parameters into the model
+     *
+     * @param pars: New parameters
+     *
+     * @param setInitialState If `true`, then changing the parameters
+     * also updates the initial conditions to use those from the
+     * model's `initial()` method. This uses the current step of the
+     * model, so you may want to use {@link Dust.setStep} first.
+     */
+    public setPars(pars: Pars, setInitialState: boolean): void {
+        const step = this.step();
+        const nState = this.nState();
+        const model = new this._Model(base, pars);
+        if (model.size() !== this.nState()) {
+            throw Error(`Particle produced unexpected state size`);
+        }
+        for (let i = 0; i < this._particles.length; ++i) {
+            const state =
+                setInitialState ? undefined : this._particles[i].state();
+            this._particles[i] = new Particle(model, step, state);
+        }
+    }
+
+    /**
+     * Change the step in the model, without updating state
+     *
+     * @param step New step
+     */
+    public setStep(step: number): void {
+        this._particles.forEach((p) => {
+            p.step = step;
+        });
+    }
+
+    /**
+     * Change the model state
+     *
+     * @param state A 2d-matrix of state; this inteface may change.
+     */
+    public setState(state: number[][]): void {
+        this.checkState(state);
+        for (let i = 0; i < this.nParticles(); ++i) {
+            this._particles[i].setState(state[i]);
+        }
+    }
+
+    /**
+     * Run the model up to some step
+     *
+     * @param stepEnd The step to run the model to
+     */
+    public run(stepEnd: number): void {
+        this._particles.forEach((p: Particle) => p.run(stepEnd, this._random));
+    }
+
+    /**
+     * Run the model and collect state at a series of times
+     *
+     * @param stepEnd An array of steps to collect state at, must be
+     * increasing. The model will stop running at the final element.
+     *
+     * @param index An index to use to filter state, or `null` to
+     * return the full state, see {@link Dust.state}
+     */
+    public simulate(stepEnd: number[], index: number[] | null): DustStateTime {
+        const nState = index === null ? this.nState() : index.length;
+        const nParticles = this.nParticles();
+        const nTime = stepEnd.length;
+        const state = dustStateTime(nState, nParticles, nTime);
+        for (let iTime = 0; iTime < nTime; ++iTime) {
+            this.run(stepEnd[iTime]);
+            for (let iParticle = 0; iParticle < nParticles; ++iParticle) {
+                const v = state.viewParticle(iParticle, iTime);
+                this._particles[iParticle].copyState(v, index);
+            }
+        }
+        return state;
+    }
+
+    /**
+     * Extract state from the model
+     *
+     * @param index An index to use to filter the model state. If
+     * given as a numeric array, then we extract `index.length` states
+     * from the model, with the `i`th extracted state coming from the
+     * models's state `index[i]`. If `null`, then the full model state
+     * is copied out.
+     */
+    public state(index: number[] | null): DustState {
+        const nState = index === null ? this.nState() : index.length;
+        const nParticles = this.nParticles();
+        const state = dustState(nState, nParticles);
+        for (let iParticle = 0; iParticle < nParticles; ++iParticle) {
+            const v = state.viewParticle(iParticle);
+            this._particles[iParticle].copyState(v, index);
+        }
+        return state;
+    }
+
+    private checkState(state: number[][]) {
+        if (state.length !== this.nParticles()) {
+            throw Error(`Invalid length state, expected ${this.nParticles()}` +
+                        ` but given ${state.length}`);
+        }
+        for (let i = 0; i < state.length; ++i) {
+            if (state[i].length !== this.nState()) {
+                throw Error(`Invalid length state for particle ${i},` +
+                            ` expected ${this.nState()}` +
+                            ` but given ${state[i].length}`);
+            }
+        }
+    }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { base, BaseType } from "./base";
+export { Dust } from "./dust";
 export { InternalStorage, Pars } from "./pars";
 export {
     DustModel,

--- a/test/dust.test.ts
+++ b/test/dust.test.ts
@@ -1,0 +1,233 @@
+import * as models from "./models";
+import { Dust } from "../src/dust";
+import { approxEqualArray, repeat } from "./helpers";
+
+import {
+    Random, RngStateBuiltin, RngState, RngStateObserved
+} from "@reside-ic/random";
+
+describe("Can create a dust object", () => {
+    const pars = {n: 1, sd: 1};
+    it("is created", () => {
+        const s = new Random(new RngStateBuiltin());
+        const p = new Dust(models.Walk, pars, 5, 0, s);
+        expect(p.step()).toEqual(0);
+        expect(p.nState()).toEqual(1);
+        expect(p.nParticles()).toEqual(5);
+        expect(p.state(null).asMatrix()).toEqual(Array(5).fill([0]));
+    });
+
+    it("Can return state", () => {
+        const s = new Random(new RngStateBuiltin());
+        const p = new Dust(models.Walk, pars, 5, 0, s);
+        expect(p.state(null).asMatrix()).toEqual(Array(5).fill([0]));
+        expect(p.state([0]).asMatrix()).toEqual(Array(5).fill([0]));
+        expect(p.state([0, 0]).asMatrix()).toEqual(Array(5).fill([0, 0]));
+    });
+
+    it("requires at least one particle", () => {
+        const s = new Random(new RngStateBuiltin());
+        expect(() => new Dust(models.Walk, pars, 0, 0, s))
+            .toThrow("Expected at least one particle");
+        expect(() => new Dust(models.Walk, pars, -5, 0, s))
+            .toThrow("Expected at least one particle");
+    });
+
+    it("Can run simulation", () => {
+        const r = new RngStateObserved(new RngStateBuiltin());
+        const s = new Random(r);
+        const cmp = new Random(r.replay());
+        const np = 5;
+        const p = new Dust(models.Walk, pars, np, 0, s);
+        p.run(2);
+        const expected = [];
+        for (let i = 0; i < 5; ++i) {
+            expected.push([cmp.randomNormal() + cmp.randomNormal()]);
+        }
+
+        expect(p.state(null).asMatrix()).toEqual(expected);
+        expect(p.step()).toEqual(2);
+    });
+});
+
+describe("Create multi-particle, multi-state objects", () => {
+    const pars = {n: 3, sd: 1};
+    it("interleaves particle state", () => {
+        const r = new RngStateObserved(new RngStateBuiltin());
+        const s = new Random(r);
+        const cmp = new Random(r.replay());
+        const p = new Dust(models.Walk, pars, 5, 0, s);
+        expect(p.step()).toEqual(0)
+        expect(p.nState()).toEqual(3)
+        expect(p.state(null).asMatrix()).toEqual(Array(5).fill([0, 0, 0]));
+        p.run(2);
+        const y = p.state(null).asMatrix();
+
+        // 3 states * 5 particles * 2 steps
+        const z = repeat(3 * 5 * 2, () => cmp.normal(0, 1));
+        // Then we need to sum these up, we do each particle in turn
+        expect(y[0]).toEqual(
+            [z[0] + z[3], z[1] + z[4], z[2] + z[5]]);
+        expect(y[1]).toEqual(
+            [z[0 + 6] + z[3 + 6], z[1 + 6] + z[4 + 6], z[2 + 6] + z[5 + 6]]);
+    });
+
+    it("can simulate, accumulating state in the expected way", () => {
+        const r = new RngStateObserved(new RngStateBuiltin());
+        const np = 5;
+        const d = new Dust(models.Walk, pars, np, 0, new Random(r));
+        const cmp = new Dust(models.Walk, pars, np, 0, new Random(r.replay()));
+
+        const res = d.simulate([0, 1, 2, 3, 4, 5, 6], null); // length 7
+
+        expect(res.getParticle(0, 0)).toEqual([0, 0, 0]);
+        expect(res.getState(0, 0)).toEqual([0, 0, 0, 0, 0]);
+        expect(res.viewTime(0).getParticle(0)).toEqual([0, 0, 0]);
+        expect(res.viewTime(0).getState(0)).toEqual([0, 0, 0, 0, 0]);
+
+        cmp.run(1);
+        const cmp1 = cmp.state(null);
+        expect(res.getParticle(0, 1)).toEqual(cmp1.getParticle(0));
+        expect(res.getParticle(3, 1)).toEqual(cmp1.getParticle(3));
+
+        // If we had proper rng streams it would not matter here and
+        // we could just run things right up time 4 in one go and the
+        // numbers would remain the same. This is fine for now though.
+        cmp.run(2);
+        cmp.run(3);
+        cmp.run(4);
+        const cmp4 = cmp.state(null);
+        expect(res.getParticle(0, 4)).toEqual(cmp4.getParticle(0));
+        expect(res.getParticle(3, 4)).toEqual(cmp4.getParticle(3));
+
+        cmp.run(5);
+        cmp.run(6);
+
+        const cmp6 = cmp.state(null);
+        expect(res.getParticle(0, 6)).toEqual(cmp6.getParticle(0));
+        expect(res.getParticle(3, 6)).toEqual(cmp6.getParticle(3));
+
+        expect(d.state(null).state.data)
+            .toEqual(cmp6.state.data);
+    });
+
+    it("can simulate, subsetting output", () => {
+        const r = new RngStateObserved(new RngStateBuiltin());
+        const np = 5;
+        const d = new Dust(models.Walk, pars, np, 0, new Random(r));
+        const cmp = new Dust(models.Walk, pars, np, 0, new Random(r.replay()));
+        const idx = [1, 2];
+        const t = [0, 1, 2, 4, 5, 6, 7];
+        const res = d.simulate(t, idx);
+        const resFull = cmp.simulate(t, null);
+        expect(res.nState).toBe(2);
+        expect(res.getState(0, 5)).toEqual(resFull.getState(1, 5));
+        expect(res.getState(1, 5)).toEqual(resFull.getState(2, 5));
+    });
+
+    it("can get model info", () => {
+        const r = new Random(new RngStateBuiltin());
+        const d = new Dust(models.Walk, pars, 5, 0, r);
+        const info = d.info();
+        expect(info).toEqual([{dim: [3], length: 3, name: "x"}]);
+    })
+});
+
+describe("can set parameters", () => {
+    it("Can change parameters", () => {
+        const p1 = {n: 3, sd: 1};
+        const p2 = {n: 3, sd: 2};
+        const np = 5;
+
+        const r = new RngStateObserved(new RngStateBuiltin());
+        const s = new Random(r);
+        const d1 = new Dust(models.Walk, p1, np, 0, s);
+        const d2 = new Dust(models.Walk, p2, np, 0, new Random(r.replay()));
+
+        d1.setPars(p2, false);
+        d1.run(1);
+        d2.run(1);
+
+        expect(d1.state(null).state.data)
+            .toEqual(d2.state(null).state.data);
+    });
+
+    it("prevents changing size of the system", () => {
+        const p1 = {n: 3, sd: 1};
+        const p2 = {n: 9, sd: 2};
+        const np = 5;
+
+        const s = new Random(new RngStateBuiltin());
+        const d = new Dust(models.Walk, p1, np, 0, s);
+        expect(() => d.setPars(p2, false))
+            .toThrow("Particle produced unexpected state size");
+    });
+
+    it("Can change parameters and update state", () => {
+        const p1 = {n: 3, sd: 1};
+        const p2 = {n: 3, sd: 2};
+        const np = 4;
+
+        const s = new Random(new RngStateBuiltin());
+        const d = new Dust(models.Walk, p1, np, 0, s);
+        d.run(5);
+        d.setPars(p2, true);
+        expect(d.state(null).asMatrix()).toEqual(Array(np).fill([5, 5, 5]))
+    });
+});
+
+describe("can set step", () => {
+    it("can be set", () => {
+        const pars = {n: 1, sd: 1};
+        const s = new Random(new RngStateBuiltin());
+        const d = new Dust(models.Walk, pars, 5, 0, s);
+        expect(d.step()).toEqual(0);
+        d.setStep(10);
+        expect(d.step()).toEqual(10);
+    });
+});
+
+describe("can set state", () => {
+    it("can set state", () => {
+        const pars = {n: 4, sd: 1};
+        const r = new RngStateObserved(new RngStateBuiltin());
+        const s = new Random(r);
+        const np = 3;
+        const d1 = new Dust(models.Walk, pars, np, 0, s);
+        const d2 = new Dust(models.Walk, pars, np, 0, new Random(r.replay()));
+
+        const state = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]];
+
+        d1.setState(state);
+        expect(d1.state(null).asMatrix()).toEqual(state);
+        d1.run(1);
+        d2.run(1);
+
+        // This can be off at the last place, stochastically because
+        // of rounding error.
+        const s1 = d1.state(null).state.data as Float64Array;
+        const s2 = d2.state(null).state.data as Float64Array;
+        for (let i = 0; i < 12; ++i) {
+            s2[i] = s2[i] + i + 1;
+        }
+        expect(approxEqualArray(s1, s2)).toEqual(true);
+    });
+
+    it("validates state as it sets it", () => {
+        const pars = {n: 2, sd: 1};
+        const r = new Random(new RngStateBuiltin());
+        const d = new Dust(models.Walk, pars, 3, 0, r);
+
+        expect(() => d.setState([[0, 1]])).toThrow(
+            "Invalid length state, expected 3 but given 1");
+        expect(() => d.setState([[0], [1], [2], [3], [4]])).toThrow(
+            "Invalid length state, expected 3 but given 5");
+        expect(() => d.setState([[0], [1], [2]])).toThrow(
+            "Invalid length state for particle 0, expected 2 but given 1");
+        expect(() => d.setState([[0, 0], [1, 1], [2, 2, 2]])).toThrow(
+            "Invalid length state for particle 2, expected 2 but given 3");
+
+        // Unchanged:
+        expect(d.state(null).asMatrix()).toEqual(Array(3).fill([0, 0]))
+    });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -2,6 +2,14 @@ import ndarray from "ndarray";
 import { dustState } from "../src/state";
 import { dustStateTime } from "../src/state-time";
 
+export function repeat<T>(n: number, f: () => T): T[] {
+    const ret = [];
+    for (let i = 0; i < n; ++i) {
+        ret.push(f());
+    }
+    return ret;
+}
+
 export function filledDustState(nState: number, nParticles: number) {
     const state = dustState(nState, nParticles);
     fillStateWithSequence(state.state);
@@ -20,4 +28,44 @@ function fillStateWithSequence(state: ndarray.NdArray) {
     for (let i = 0; i < d.length; ++i) {
         d[i] = i;
     }
+}
+
+const sqrtDoubleEpsilon = Math.pow(2, -52 / 2);
+
+export function approxEqual(x: number, y: number,
+                            tolerance = sqrtDoubleEpsilon) {
+    let xy = Math.abs(x - y);
+    const xn = Math.abs(x);
+    if (xn > tolerance) {
+        xy /= xn;
+    }
+    return xy < tolerance;
+}
+
+export function approxEqualArray(x: Float64Array, y: Float64Array,
+                                 tolerance = sqrtDoubleEpsilon) {
+    if (y.length !== x.length) {
+        throw Error("Incompatible arrays");
+    }
+    let scale = 0;
+    let xy = 0;
+    let n = 0;
+    for (let i = 0; i < x.length; ++i) {
+        if (x[i] !== y[i]) {
+            scale += Math.abs(x[i]);
+            xy += Math.abs(x[i] - y[i]);
+            n++;
+        }
+    }
+    if (n === 0) {
+        return true;
+    }
+
+    scale /= n;
+    xy /= n;
+
+    if (scale > tolerance) {
+        xy /= scale;
+    }
+    return xy < tolerance;
 }


### PR DESCRIPTION
This PR adds a dust class to organise running a set of particles in a stochastic simulation.

I've not yet implemented support for reordering, just for forward simulation, as that's not strictly needed for wodin, but will do that in a PR soon as it should be fairly straightforward