### PR TITLE
Support particle reordering

### DIFF
--- a/src/dust.ts
+++ b/src/dust.ts
@@ -177,6 +177,36 @@ export class Dust {
         return state;
     }
 
+    /**
+     * Reorder particle state among particles
+     *
+     * @param index An integer array of length `nParticles`, with
+     * values between 0 and `nParticles`, indicating the index of the
+     * particle that each particle should end up taking. So if the
+     * `i`th element is `j`, then after reordering particle `i` will
+     * have the state that particle `j` currently has. Indices can be
+     * repeated, and typically will be; i.e., this is a resampling
+     * rather than a strict shuffle.
+     */
+    public reorder(index: number[]): void {
+        const nParticles = this.nParticles();
+        if (index.length !== nParticles) {
+            throw Error(`Expected index to have length ${nParticles}` +
+                        ` but given ${index.length}`);
+        }
+        this.forEachParticle((p: Particle, idx: number) => {
+            const j = index[idx];
+            if (j < 0 || j >= nParticles) {
+                throw Error(`Expected index to be in [0, ${nParticles - 1}]` +
+                            ` but given ${j}`);
+            }
+            p.setState(this._particles[j].state(), true);
+        });
+        this.forEachParticle((p: Particle, idx: number) => {
+            p.swap();
+        });
+    }
+
     private forEachParticle(fn: (p: Particle, idx: number) => void) {
         this._particles.forEach(fn);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,6 @@ export {
     DustModelInfo,
     DustModelVariable
 } from "./model";
+export { Particle } from "./particle";
 export { dustState, DustState, VectorView } from "./state";
 export { dustStateTime, DustStateTime } from "./state-time";

--- a/src/particle.ts
+++ b/src/particle.ts
@@ -98,10 +98,18 @@ export class Particle {
      * Set particle state
      *
      * @param state New state, must be of length `size`
+     *
+     * @param next Update the *next* state, rather than the current
+     * state. If `true`, then the particle state as returned by {@link
+     * Particle.state} will not be affected and you will need to call
+     * {@link Particle.swap} in order to make the state take
+     * effect. This is used when shuffling particles, via {@link
+     * Dust.reorder}.
      */
-    public setState(state: number[]): void {
+    public setState(state: readonly number[], next: boolean = false): void {
+        const dest = next ? this._yNext : this._y;
         for (let i = 0; i < state.length; ++i) {
-            this._y[i] = state[i];
+            dest[i] = state[i];
         }
     }
 

--- a/test/dust.test.ts
+++ b/test/dust.test.ts
@@ -231,3 +231,78 @@ describe("can set state", () => {
         expect(d.state(null).asMatrix()).toEqual(Array(3).fill([0, 0]))
     });
 });
+
+
+describe("can reorder particles", () => {
+    it("reorders without duplication", () => {
+        const pars = {n: 4, sd: 1};
+        const r = new RngStateObserved(new RngStateBuiltin());
+        const s = new Random(r);
+        const np = 3;
+        const d1 = new Dust(models.Walk, pars, np, 0, s);
+        const d2 = new Dust(models.Walk, pars, np, 0, new Random(r.replay()));
+        const state1 = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]];
+        const state2 = [[9, 10, 11, 12], [5, 6, 7, 8], [1, 2, 3, 4]];
+
+        d1.setState(state1);
+        d1.reorder([2, 1, 0]);
+
+        expect(d1.state(null).asMatrix()).toEqual(state2);
+        d1.run(1);
+
+        d2.setState(state2);
+        d2.run(1);
+
+        expect(d1.state(null).asMatrix()).toEqual(d1.state(null).asMatrix())
+    });
+
+    it("reorders with duplication", () => {
+        const pars = {n: 4, sd: 1};
+        const r = new RngStateObserved(new RngStateBuiltin());
+        const s = new Random(r);
+        const np = 3;
+        const d1 = new Dust(models.Walk, pars, np, 0, s);
+        const d2 = new Dust(models.Walk, pars, np, 0, new Random(r.replay()));
+        const state1 = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]];
+        const state2 = [[5, 6, 7, 8], [5, 6, 7, 8], [5, 6, 7, 8]];
+
+        d1.setState(state1);
+        d1.reorder([1, 1, 1]);
+
+        expect(d1.state(null).asMatrix()).toEqual(state2);
+        d1.run(1);
+
+        d2.setState(state2);
+        d2.run(1);
+
+        expect(d1.state(null).asMatrix()).toEqual(d1.state(null).asMatrix())
+    });
+
+    it("requires that index is the correct length", () => {
+        const pars = {n: 4, sd: 1};
+        const s = new Random(new RngStateBuiltin());
+        const np = 3;
+        const d = new Dust(models.Walk, pars, np, 0, s);
+        const state = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]];
+        d.setState(state);
+        expect(() => d.reorder([2, 1]))
+            .toThrow("Expected index to have length 3 but given 2");
+        expect(() => d.reorder([2, 1, 1, 2]))
+            .toThrow("Expected index to have length 3 but given 4");
+        expect(d.state(null).asMatrix()).toEqual(state);
+    });
+
+    it("requires that index values are in the correct range", () => {
+        const pars = {n: 4, sd: 1};
+        const s = new Random(new RngStateBuiltin());
+        const np = 3;
+        const d = new Dust(models.Walk, pars, np, 0, s);
+        const state = [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]];
+        d.setState(state);
+        expect(() => d.reorder([2, 1, -1]))
+            .toThrow("Expected index to be in [0, 2] but given -1");
+        expect(() => d.reorder([2, 1, 3]))
+            .toThrow("Expected index to be in [0, 2] but given 3");
+        expect(d.state(null).asMatrix()).toEqual(state);
+    });
+});


### PR DESCRIPTION
This is really not needed for the bits to support the short course, but gets us towards a particle filter in js which I think will be fun to play with and could be cool for the next iteration of wodin. Plus I just wanted something easy to implement before diving back into wodin.

This PR implements the same reordering approach as dust (and mode). Failure to reorder does not change particle state, and reordering can be done with replacement.
