### PR TITLE
Add support for extracting a trace over time

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-    "name": "dust",
+    "name": "@reside-ic/dust",
     "version": "0.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "name": "dust",
+            "name": "@reside-ic/dust",
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "dust",
+    "name": "@reside-ic/dust",
     "version": "0.0.1",
     "description": "Dust-like interface for js",
     "main": "index.js",

--- a/src/state-time.ts
+++ b/src/state-time.ts
@@ -88,6 +88,16 @@ export class DustStateTime {
         return this.state.pick(iTime, null, iState);
     }
 
+    /** Construct a {@link VectorView} for a single trace (or
+     * variable) for a single particle over all points in time. This
+     * can then be easily read from or written to.
+     * @param iState The index of the state to fetch
+     * @param iParticle The index of the particle to fetch
+     */
+    public viewTrace(iState: number, iParticle: number): VectorView {
+        return this.state.pick(null, iParticle, iState);
+    }
+
     /**
      * Copy the state for a single vector at a single point in time
      * into a plain JavaScript numeric array. This will then be
@@ -108,5 +118,16 @@ export class DustStateTime {
      */
     public getState(iState: number, iTime: number): number[] {
         return copyVector(this.viewState(iState, iTime));
+    }
+
+    /**
+     * Copy the state for a single trace of a variable for a single
+     * particle over all time points into a plain JavaScript numeric
+     * array. This will then be decoupled from the underlying object
+     * @param iState The index of the state to fetch
+     * @param iParticle The index of the particle to fetch
+     */
+    public getTrace(iState: number, iParticle: number): number[] {
+        return copyVector(this.viewTrace(iState, iParticle));
     }
 }

--- a/test/state-time.test.ts
+++ b/test/state-time.test.ts
@@ -43,4 +43,13 @@ describe("dust state at multiple time points", () => {
         expect(state.getState(0, 5)).toEqual(t5.getState(0));
         expect(state.getState(3, 5)).toEqual(t5.getState(3));
     });
+
+    it("can extract a specific trace", () => {
+        const state = filledDustStateTime(nState, nParticles, nTime);
+        const expected = [0, 35, 70, 105, 140, 175, 210, 245, 280, 315, 350];
+        expect(state.getTrace(0, 0)).toEqual(expected);
+        expect(state.getTrace(1, 0)).toEqual(expected.map((x) => x + 1));
+        expect(state.getTrace(0, 1)).toEqual(expected.map((x) => x + 5));
+        expect(state.getTrace(1, 1)).toEqual(expected.map((x) => x + 6));
+    });
 });

--- a/test/state-time.test.ts
+++ b/test/state-time.test.ts
@@ -1,3 +1,4 @@
+import { copyVector } from "../src/state";
 import { dustStateTime } from "../src/state-time";
 
 import { filledDustStateTime } from "./helpers";
@@ -47,9 +48,31 @@ describe("dust state at multiple time points", () => {
     it("can extract a specific trace", () => {
         const state = filledDustStateTime(nState, nParticles, nTime);
         const expected = [0, 35, 70, 105, 140, 175, 210, 245, 280, 315, 350];
+
         expect(state.getTrace(0, 0)).toEqual(expected);
         expect(state.getTrace(1, 0)).toEqual(expected.map((x) => x + 1));
         expect(state.getTrace(0, 1)).toEqual(expected.map((x) => x + 5));
         expect(state.getTrace(1, 1)).toEqual(expected.map((x) => x + 6));
+    });
+
+    it("makes a copy when getting a trace", () => {
+        const state = filledDustStateTime(nState, nParticles, nTime);
+        const expected = [0, 35, 70, 105, 140, 175, 210, 245, 280, 315, 350];
+
+        const yView = state.viewTrace(0, 0);
+        const yCopy = state.getTrace(0, 0);
+
+        expect(copyVector(yView)).toEqual(expected);
+        expect(yCopy).toEqual(expected);
+
+        yCopy[0] = 10;
+        expect(state.getTrace(0, 0)).toEqual(expected);
+        expect(copyVector(yView)).toEqual(expected);
+
+        yView.set(0, 10);
+        expect(state.getTrace(0, 0)).not.toEqual(expected);
+        expect(copyVector(yView)).not.toEqual(expected);
+        expect(state.getTrace(0, 0)).toEqual([10, ...expected.slice(1)]);
+        expect(copyVector(yView)).toEqual([10, ...expected.slice(1)]);
     });
 });


### PR DESCRIPTION
Should have done this with the state, but this is the third way of extracting a vector from a 3d matrix (keeping time and fixing state/particle). This will be useful when creating a set of traces ready for use with plotly (creating a `SeriesSet` in odin-js)