### PR TITLE
Add package wrapper to call from R

### DIFF
--- a/src/dust.ts
+++ b/src/dust.ts
@@ -49,7 +49,7 @@ export class Dust {
         // workers we might need to revisit this approach, but the API
         // there looks nothing like OpenMP and this would probably
         // still be ok, once per worker.
-        const model = new Model(base, pars);
+        const model = new Model(base, pars, "ignore");
         for (let i = 0; i < nParticles; ++i) {
             this._particles.push(new Particle(model, step));
         }
@@ -97,7 +97,7 @@ export class Dust {
     public setPars(pars: UserType, setInitialState: boolean): void {
         const step = this.step();
         const nState = this.nState();
-        const model = new this._Model(base, pars);
+        const model = new this._Model(base, pars, "ignore");
         if (model.size() !== this.nState()) {
             throw Error(`Particle produced unexpected state size`);
         }

--- a/src/dust.ts
+++ b/src/dust.ts
@@ -121,7 +121,7 @@ export class Dust {
     /**
      * Change the model state
      *
-     * @param state A 2d-matrix of state; this inteface may change.
+     * @param state A 2d-matrix of state; this interface may change.
      */
     public setState(state: number[][]): void {
         this.checkState(state);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,6 @@ export {
     DustModelVariable
 } from "./model";
 export { Particle } from "./particle";
+export { PkgWrapper } from "./pkg";
 export { dustState, DustState, VectorView } from "./state";
 export { dustStateTime, DustStateTime } from "./state-time";

--- a/src/model.ts
+++ b/src/model.ts
@@ -13,7 +13,7 @@ export { InternalStorage, UserType };
  * @param pars Parameters to pass to the model
  *
  */
-export type DustModelConstructable = new(base: BaseType, pars: UserType) => DustModel;
+export type DustModelConstructable = new(base: BaseType, pars: UserType, unusedUserAction: string) => DustModel;
 
 /**
  * Information returned by an initialised model about itself

--- a/src/model.ts
+++ b/src/model.ts
@@ -83,4 +83,10 @@ export interface DustModel {
      * @param random The random state, used for any stochastic updates
      */
     update(step: number, y: readonly number[], yNext: number[], random: Random): void;
+
+    /**
+     * Return the state of the internal storage - odin uses this for
+     * debugging and testing.
+     */
+    getInternal(): InternalStorage;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -12,6 +12,11 @@ export { InternalStorage, UserType };
  *
  * @param pars Parameters to pass to the model
  *
+ * @param unusedUserAction String describing the behaviour if unused
+ * values are found in `pars`. Typically this should be the string
+ * "ignore" for dust models but for compatibility with odin (and use
+ * with {@link PkgWrapper}) the values "message", "warning" and "stop"
+ * are supported.
  */
 export type DustModelConstructable = new(base: BaseType, pars: UserType, unusedUserAction: string) => DustModel;
 

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -79,7 +79,7 @@ export class PkgWrapper {
 
 export function variableNames(info: DustModelInfo): string[] {
     const ret: string[] = [];
-    for (let el of info) {
+    for (const el of info) {
         const { dim, name } = el;
         if (dim.length === 0) {
             ret.push(name);

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -29,8 +29,8 @@ export class PkgWrapper {
         this.model = new this.Model(base, pars);
     }
 
-    public static random(rng?: RngState) {
-        return new Random(rng || new RngStateBuiltin());
+    public static random(rng: RngState) {
+        return new Random(rng);
     }
 
     public setUser(pars: UserType) {

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -2,7 +2,13 @@ import { Random, RngState, RngStateBuiltin } from "@reside-ic/random";
 
 import { base } from "./base";
 import { Dust } from "./dust";
-import { DustModel, DustModelInfo, DustModelConstructable, InternalStorage, UserType } from "./model";
+import {
+    DustModel,
+    DustModelInfo,
+    DustModelConstructable,
+    InternalStorage,
+    UserType
+} from "./model";
 import { copyVector } from "./state";
 import { combinations } from "./util";
 
@@ -11,31 +17,27 @@ import { combinations } from "./util";
 // we'll eventually remove as it's not very useful. However, we need
 // to support the existing interface in order to complete the port of
 // the js support before doing any refactor in odin so here we are!
-//
-// The biggest sources of difference are:
-//
-// * how we handle metadata
-// * how we handle updating of parameters
 export class PkgWrapper {
     private readonly Model: DustModelConstructable;
     private pars: UserType;
     private model: DustModel;
     private random: Random;
 
-    constructor(Model: DustModelConstructable, pars: UserType, rng?: RngState) {
+    constructor(Model: DustModelConstructable, pars: UserType,
+                unusedUserAction: string, rng?: RngState) {
         this.Model = Model;
         this.pars = pars;
         this.random = new Random(rng || new RngStateBuiltin());
-        this.model = new this.Model(base, pars);
+        this.model = new this.Model(base, pars, unusedUserAction);
     }
 
     public static random(rng: RngState) {
         return new Random(rng);
     }
 
-    public setUser(pars: UserType) {
-        this.pars = pars; // TODO: { ...this.pars, pars };
-        this.model = new this.Model(base, pars);
+    public setUser(pars: UserType, unusedUserAction: string) {
+        this.pars = pars;
+        this.model = new this.Model(base, pars, unusedUserAction);
     }
 
     public initial(step: number): number[] {
@@ -64,7 +66,8 @@ export class PkgWrapper {
     public run(step: number[], y: number[] | null) {
         const stepStart = step[0];
         const nParticles = 1;
-        const dust = new Dust(this.Model, this.pars, nParticles, stepStart, this.random);
+        const dust = new Dust(this.Model, this.pars, nParticles, stepStart,
+                              this.random);
         if (y !== null) {
             dust.setState([y]);
         }
@@ -84,7 +87,8 @@ export function variableNames(info: DustModelInfo): string[] {
         if (dim.length === 0) {
             ret.push(name);
         } else {
-            ret.push(...combinations(dim).map((i) => `${name}[${i.join(",")}]`));
+            ret.push(...combinations(dim).map(
+                (i) => `${name}[${i.join(",")}]`));
         }
     }
     return ret;

--- a/src/pkg.ts
+++ b/src/pkg.ts
@@ -1,0 +1,91 @@
+import { Random, RngState, RngStateBuiltin } from "@reside-ic/random";
+
+import { base } from "./base";
+import { Dust } from "./dust";
+import { DustModel, DustModelInfo, DustModelConstructable, InternalStorage, UserType } from "./model";
+import { copyVector } from "./state";
+import { combinations } from "./util";
+
+// This interface exists to support testing in the R package and is
+// quite annoying because it needs to support a model of running that
+// we'll eventually remove as it's not very useful. However, we need
+// to support the existing interface in order to complete the port of
+// the js support before doing any refactor in odin so here we are!
+//
+// The biggest sources of difference are:
+//
+// * how we handle metadata
+// * how we handle updating of parameters
+export class PkgWrapper {
+    private readonly Model: DustModelConstructable;
+    private pars: UserType;
+    private model: DustModel;
+    private random: Random;
+
+    constructor(Model: DustModelConstructable, pars: UserType, rng?: RngState) {
+        this.Model = Model;
+        this.pars = pars;
+        this.random = new Random(rng || new RngStateBuiltin());
+        this.model = new this.Model(base, pars);
+    }
+
+    public static random(rng?: RngState) {
+        return new Random(rng || new RngStateBuiltin());
+    }
+
+    public setUser(pars: UserType) {
+        this.pars = pars; // TODO: { ...this.pars, pars };
+        this.model = new this.Model(base, pars);
+    }
+
+    public initial(step: number): number[] {
+        return this.model.initial(step);
+    }
+
+    public update(step: number, y: number[]): number[] {
+        const yNext = Array(y.length).fill(0);
+        this.model.update(step, y, yNext, this.random);
+        return yNext;
+    }
+
+    public getInternal(): InternalStorage {
+        return this.model.getInternal();
+    }
+
+    public getMetadata() {
+        const info = this.model.info();
+        return {
+            info,
+            names: variableNames(info),
+            size: this.model.size(),
+        };
+    }
+
+    public run(step: number[], y: number[] | null) {
+        const stepStart = step[0];
+        const nParticles = 1;
+        const dust = new Dust(this.Model, this.pars, nParticles, stepStart, this.random);
+        if (y !== null) {
+            dust.setState([y]);
+        }
+        const state = dust.simulate(step, null);
+
+        return {
+            size: this.model.size(),
+            y: Array.from(state.state.data as Float64Array)
+        }
+    }
+}
+
+export function variableNames(info: DustModelInfo): string[] {
+    const ret: string[] = [];
+    for (let el of info) {
+        const { dim, name } = el;
+        if (dim.length === 0) {
+            ret.push(name);
+        } else {
+            ret.push(...combinations(dim).map((i) => `${name}[${i.join(",")}]`));
+        }
+    }
+    return ret;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -12,10 +12,10 @@ export function combinations(arr: number[]): number[][] {
 
     if (arr.length > 1) {
         const rest = combinations(arr.slice(1));
-        const ret = [];
-        for (let i = 0; i < rest.length; ++i) {
-            for (let j = 0; j < n.length; ++j) {
-                ret.push([n[j], ...rest[i]])
+        const ret = [] as number[][];
+        for (const i of rest) {
+            for (const j of n) {
+                ret.push([j, ...i]);
             }
         }
         return ret;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,25 @@
+export function seq(a: number, b: number): number[] {
+    const ret = [];
+    for (let i = a; i <= b; ++i) {
+        ret.push(i);
+    }
+    return ret;
+}
+
+export function combinations(arr: number[]): number[][] {
+    const ret: number[][] = [];
+    const n = seq(1, arr[0]);
+
+    if (arr.length > 1) {
+        const rest = combinations(arr.slice(1));
+        const ret = [];
+        for (let i = 0; i < rest.length; ++i) {
+            for (let j = 0; j < n.length; ++j) {
+                ret.push([n[j], ...rest[i]])
+            }
+        }
+        return ret;
+    } else {
+        return n.map((el: number) => [el]);
+    }
+}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -69,3 +69,11 @@ export function approxEqualArray(x: Float64Array, y: Float64Array,
     }
     return xy < tolerance;
 }
+
+export function cumsum(x: number[]): number[] {
+    const ret: number[] = [];
+    x.forEach((el, i) => {
+        ret.push(i === 0 ? el : el + ret[i - 1]);
+    })
+    return ret;
+}

--- a/test/models.ts
+++ b/test/models.ts
@@ -38,4 +38,8 @@ export class Walk implements DustModel {
             yNext[i] = random.normal(y[i], sd);
         }
     }
+
+    public getInternal(): InternalStorage {
+        return this.internal;
+    }
 }

--- a/test/models.ts
+++ b/test/models.ts
@@ -10,8 +10,9 @@ import type { DustModel, DustModelInfo, InternalStorage, UserType } from "../src
 export class Walk implements DustModel {
     private readonly internal: InternalStorage;
 
-    constructor(base: BaseType, pars: UserType) {
+    constructor(base: BaseType, pars: UserType, unusedUserAction: string = "ignore") {
         this.internal = {};
+        base.user.checkUser(pars, ["n", "sd"], unusedUserAction);
         base.user.setUserScalar(pars, "n", this.internal, 1,
                                 -Infinity, Infinity, false);
         base.user.setUserScalar(pars, "sd", this.internal, 1,

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -2,7 +2,7 @@ import {
     Random, RngStateBuiltin, RngState, RngStateObserved
 } from "@reside-ic/random";
 
-import { PkgWrapper } from "../src/pkg";
+import { PkgWrapper, variableNames } from "../src/pkg";
 
 import * as models from "./models";
 import { cumsum, repeat } from "./helpers";
@@ -72,5 +72,32 @@ describe("wrapper", () => {
         const y = mod.run([0, 1, 2, 3, 4], [10]);
         // expect(y.info).toStrictEqual(mod.getMetadata());
         expect(y.y).toStrictEqual(cumsum([10, ...repeat(4, () => cmp.normal(0, 1))]));
+    });
+});
+
+describe("variableNames", () => {
+    it("can generate simple names", () => {
+        expect(variableNames([{ dim: [], length: 1, name: "x" }]))
+            .toEqual(["x"]);
+        expect(variableNames([
+            { dim: [], length: 1, name: "x" },
+            { dim: [], length: 1, name: "y" }
+        ])).toEqual(["x", "y"]);
+    });
+
+    it("can generate vector names", () => {
+        expect(variableNames([
+            { dim: [3], length: 3, name: "x" }
+        ])).toEqual(["x[1]", "x[2]", "x[3]"]);
+        expect(variableNames([
+            { dim: [], length: 1, name: "x" },
+            { dim: [3], length: 3, name: "y" }
+        ])).toEqual(["x", "y[1]", "y[2]", "y[3]"]);
+    });
+
+    it("can generate matrix names", () => {
+        expect(variableNames([
+            { dim: [2, 3], length: 3, name: "x" }
+        ])).toEqual(["x[1,1]", "x[2,1]", "x[1,2]", "x[2,2]", "x[1,3]", "x[2,3]"]);
     });
 });

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -73,6 +73,14 @@ describe("wrapper", () => {
         // expect(y.info).toStrictEqual(mod.getMetadata());
         expect(y.y).toStrictEqual(cumsum([10, ...repeat(4, () => cmp.normal(0, 1))]));
     });
+
+    it("can create a random object staticically", () => {
+        const rng = new RngStateObserved(new RngStateBuiltin());
+        const r1 = PkgWrapper.random(rng);
+        const r2 = PkgWrapper.random(rng.replay());
+        const y = repeat(10, () => r1.randomNormal());
+        expect(y).toEqual(repeat(10, () => r2.randomNormal()));
+    });
 });
 
 describe("variableNames", () => {

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -1,0 +1,76 @@
+import {
+    Random, RngStateBuiltin, RngState, RngStateObserved
+} from "@reside-ic/random";
+
+import { PkgWrapper } from "../src/pkg";
+
+import * as models from "./models";
+import { cumsum, repeat } from "./helpers";
+
+describe("wrapper", () => {
+    it("can create a simple wrapped model", () => {
+        const rng = new RngStateObserved(new RngStateBuiltin());
+        const cmp = new Random(rng.replay());
+        const pars = {};
+        const mod = new PkgWrapper(models.Walk, pars, rng);
+
+        expect(mod.initial(0)).toEqual([0]);
+        const y = mod.update(0, [0]);
+        expect(y).toStrictEqual([cmp.normal(0, 1)]);
+
+        const info = mod.getMetadata();
+        const internal = mod.getInternal();
+    });
+
+    it("can get model metadata", () => {
+        const pars = {n: 5, sd: 2};
+        const mod = new PkgWrapper(models.Walk, pars);
+        const meta = mod.getMetadata();
+        expect(meta).toStrictEqual({
+            info: [{ dim: [5], length: 5, name: "x" }],
+            names: ["x[1]", "x[2]", "x[3]", "x[4]", "x[5]"],
+            size: 5
+        });
+    });
+
+    it("can get model internals", () => {
+        const pars = {n: 5, sd: 2};
+        const mod = new PkgWrapper(models.Walk, pars);
+        const internal = mod.getInternal();
+        expect(internal).toStrictEqual({ n: 5, sd: 2 });
+    });
+
+    it("can change parameters", () => {
+        const rng = new RngStateObserved(new RngStateBuiltin());
+        const cmp = new Random(rng.replay());
+        const pars = {};
+        const mod = new PkgWrapper(models.Walk, pars, rng);
+        expect(mod.getInternal()).toEqual({ n: 1, sd: 1 });
+        const y1 = mod.update(0, [0]);
+        expect(y1).toStrictEqual([cmp.normal(0, 1)]);
+        mod.setUser({ n: 1, sd: 2 });
+        expect(mod.getInternal()).toEqual({ n: 1, sd: 2 });
+        const y2 = mod.update(0, [0]);
+        expect(y2).toStrictEqual([cmp.normal(0, 2)]);
+    });
+
+    it("can run model from default initial conditions", () => {
+        const rng = new RngStateObserved(new RngStateBuiltin());
+        const cmp = new Random(rng.replay());
+        const pars = {};
+        const mod = new PkgWrapper(models.Walk, pars, rng);
+        const y = mod.run([0, 1, 2, 3, 4], null);
+        // expect(y.info).toStrictEqual(mod.getMetadata());
+        expect(y.y).toStrictEqual(cumsum([0, ...repeat(4, () => cmp.normal(0, 1))]));
+    });
+
+    it("can run model from given starting y", () => {
+        const rng = new RngStateObserved(new RngStateBuiltin());
+        const cmp = new Random(rng.replay());
+        const pars = {};
+        const mod = new PkgWrapper(models.Walk, pars, rng);
+        const y = mod.run([0, 1, 2, 3, 4], [10]);
+        // expect(y.info).toStrictEqual(mod.getMetadata());
+        expect(y.y).toStrictEqual(cumsum([10, ...repeat(4, () => cmp.normal(0, 1))]));
+    });
+});

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,0 +1,21 @@
+import { combinations, seq } from "../src/util";
+
+describe("seq", () => {
+    it("generates an inclusive sequence", () => {
+        expect(seq(2, 5)).toStrictEqual([2, 3, 4, 5]);
+        expect(seq(2, 2)).toStrictEqual([2]);
+    });
+
+    it("copes with impossible case gracefully", () => {
+        expect(seq(2, 1)).toStrictEqual([]);
+    });
+});
+
+describe("combinations", () => {
+    expect(combinations([])).toEqual([]);
+    expect(combinations([1])).toEqual([[1]]);
+    expect(combinations([2])).toEqual([[1], [2]]);
+    expect(combinations([2, 3])).toEqual([
+        [1, 1], [2, 1], [1, 2], [2, 2], [1, 3], [2, 3]
+    ]);
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,8 @@ module.exports = {
         extensions: ['.tsx', '.ts', '.js'],
     },
     output: {
-        library: 'dfoptim',
-        filename: 'dfoptim.js',
+        library: 'dust',
+        filename: 'dust.js',
         path: path.resolve(__dirname, 'dist'),
     },
 };


### PR DESCRIPTION
~Merge after https://github.com/mrc-ide/dust-js/pull/6 as it contains these commits~

This PR adds a package runner for use from odin; see https://github.com/mrc-ide/odin/pull/273 which uses this PR (via the webpack-created file).

The basic pattern follows odin-js (https://github.com/mrc-ide/odin-js/blob/main/src/pkg.ts), providing methods that are primarily interesting for use from R. These need to match how the existing C and R targets work, which does not really reflect the way we designed dust.js (which follows dust), so there's a bit of double handling the dust object and a copy of the model. We then use this in the odin tests to make sure that we generate correct code.

A runner that works for wodin will follow in the next PR, this code will never be used in the webapp
