### PR TITLE
Sensitivity/batch runner based on new odin-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@reside-ic/dust",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/dust",
-            "version": "0.0.1",
+            "version": "0.0.2",
             "license": "MIT",
             "dependencies": {
-                "@reside-ic/odinjs": "^0.0.18",
+                "@reside-ic/odinjs": "^0.1.0",
                 "@reside-ic/random": "^0.0.3",
                 "ndarray": "^1.0.19"
             },
@@ -1105,9 +1105,9 @@
             }
         },
         "node_modules/@reside-ic/odinjs": {
-            "version": "0.0.18",
-            "resolved": "https://registry.npmjs.org/@reside-ic/odinjs/-/odinjs-0.0.18.tgz",
-            "integrity": "sha512-GHL3snPewrwTUSv3TFPkaNroQU//W8M8mpQ5T61S+henlXgIZWMAwxn5DWvKBmtjBf5nYLYUwf61/tFDacjBdQ==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@reside-ic/odinjs/-/odinjs-0.1.0.tgz",
+            "integrity": "sha512-rLx2WIWszn4Pk9Q5bAMlZM89QcDNgBkCmjqdyPksqbp/vesezFDaC5YPQWOgKOeVl/9CwbHU5ImJvSTwM1zkJw==",
             "dependencies": {
                 "@reside-ic/interpolate": "^0.0.1",
                 "dfoptim": "^0.0.5",
@@ -6630,9 +6630,9 @@
             }
         },
         "@reside-ic/odinjs": {
-            "version": "0.0.18",
-            "resolved": "https://registry.npmjs.org/@reside-ic/odinjs/-/odinjs-0.0.18.tgz",
-            "integrity": "sha512-GHL3snPewrwTUSv3TFPkaNroQU//W8M8mpQ5T61S+henlXgIZWMAwxn5DWvKBmtjBf5nYLYUwf61/tFDacjBdQ==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@reside-ic/odinjs/-/odinjs-0.1.0.tgz",
+            "integrity": "sha512-rLx2WIWszn4Pk9Q5bAMlZM89QcDNgBkCmjqdyPksqbp/vesezFDaC5YPQWOgKOeVl/9CwbHU5ImJvSTwM1zkJw==",
             "requires": {
                 "@reside-ic/interpolate": "^0.0.1",
                 "dfoptim": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/dust",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Dust-like interface for js",
     "main": "index.js",
     "scripts": {
@@ -38,7 +38,7 @@
         "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@reside-ic/odinjs": "^0.0.18",
+        "@reside-ic/odinjs": "^0.1.0",
         "@reside-ic/random": "^0.0.3",
         "ndarray": "^1.0.19"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,10 @@ export { dustState, DustState, VectorView } from "./state";
 export { dustStateTime, DustStateTime } from "./state-time";
 export { versions } from "./versions";
 export {
+    batchRunDiscrete,
     DiscreteSeriesMode,
     DiscreteSeriesSet,
     DiscreteSeriesValues,
+    FilteredDiscreteSolution,
     wodinRunDiscrete
 } from "./wodin";

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -2,7 +2,7 @@
 export function versions() {
     return {
         random: "0.0.3",
-        odinjs: "0.0.18",
-        dust: "0.0.1",
+        odinjs: "0.1.0",
+        dust: "0.0.2",
     };
 }

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -75,6 +75,11 @@ interface DiscreteSolution {
     times: number[];
 }
 
+/**
+ * The discrete-time version of odin-js's `InterpolatedSolution`; the
+ * solution is not interpolated here, but we filter times based on the
+ * requested times and the times available from the simulation.
+ */
 export type FilteredDiscreteSolution = (times: Times) => DiscreteSeriesSet;
 
 export function runModelDiscrete(Model: DustModelConstructable,
@@ -216,6 +221,24 @@ export function tidyDiscreteSolutionVariable(name: string, solution: DiscreteSol
     }
 }
 
+/**
+ * Run a series of runs of a discrete-time model, returning a set of
+ * solutions.
+ *
+ * @param Model The model constructor
+ *
+ * @param pars Parameters of the model, and information about the one
+ * to vary. Most easily generated with odin-js's `batchParsRange` or
+ * `batchParsDisplace`
+ *
+ * @param timeStart Start of the simulation (often 0)
+ *
+ * @param timeEnd End of the simulation (must be greater than `timeStart`)
+ *
+ * @param dt The size of each step
+ *
+ * @param nParticles The number of independent particles (replicates) to run
+ */
 export function batchRunDiscrete(Model: DustModelConstructable, pars: BatchPars,
                                  timeStart: number, timeEnd: number,
                                  dt: number, nParticles: number): Batch {

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -1,4 +1,11 @@
-import { Times, TimeMode } from "@reside-ic/odinjs";
+import {
+    Batch,
+    BatchPars,
+    InterpolatedSolution,
+    SeriesSet,
+    Times,
+    TimeMode
+} from "@reside-ic/odinjs";
 
 import { Dust } from "./dust";
 import type { DustModel, DustModelInfo, DustModelConstructable, UserType } from "./model";
@@ -207,4 +214,26 @@ export function tidyDiscreteSolutionVariable(name: string, solution: DiscreteSol
             y: first
         }]
     }
+}
+
+export function batchRunDiscrete(Model: DustModelConstructable, pars: BatchPars,
+                                 timeStart: number, timeEnd: number,
+                                 dt: number, nParticles: number): Batch {
+    const run = (p: UserType, t0: number, t1: number) =>
+        centralOnly(wodinRunDiscrete(Model, p, t0, t1, dt, nParticles));
+    return new Batch(run, pars, timeStart, timeEnd);
+}
+
+export function centralOnly(solution: FilteredDiscreteSolution): InterpolatedSolution {
+    return (times: Times) => filterToCentralOnly(solution(times));
+}
+
+export function filterToCentralOnly(result: DiscreteSeriesSet): SeriesSet {
+    const values = result.values
+        .filter((el: DiscreteSeriesValues) => el.mode !== DiscreteSeriesMode.Individual)
+        .map((el: DiscreteSeriesValues) => ({ name: el.name, y: el.y }));
+    return {
+        x: result.x,
+        values
+    };
 }

--- a/test/models.ts
+++ b/test/models.ts
@@ -16,7 +16,7 @@ export class Walk implements DustModel {
         base.user.setUserScalar(pars, "n", this.internal, 1,
                                 -Infinity, Infinity, false);
         base.user.setUserScalar(pars, "sd", this.internal, 1,
-                                -Infinity, Infinity, false);
+                                0, Infinity, false);
     }
 
     public size(): number {

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -178,6 +178,9 @@ describe("can run batch", () => {
     });
 
     it("can report on near miss values", () => {
+        // Unlike odin, if the user asks for a specific time it might
+        // not be present due to floating point differences; check
+        // that if they're close to a time we get the right time back.
         const tEnd = 10;
         const dt = 0.1;
         const nParticles = 7;

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -3,6 +3,7 @@ import { Times, TimeMode } from "@reside-ic/odinjs";
 import { dustStateTime } from "../src/state-time";
 import { meanArray, seq, seqBy } from "../src/util";
 import {
+    batchRunDiscrete,
     filterIndex,
     tidyDiscreteSolution,
     tidyDiscreteSolutionVariable,
@@ -130,5 +131,90 @@ describe("can filter", () => {
             times: [3.141, 7.7713]
         };
         expect(filterIndex(t, times)).toStrictEqual([31, 78]);
+    });
+});
+
+describe("can run batch", () => {
+    const allTimes = {
+        mode: TimeMode.Grid as const,
+        tStart: 0,
+        tEnd: 10,
+        nPoints: Infinity
+    };
+    it("can run", () => {
+        const tEnd = 10;
+        const dt = 0.1;
+        const nParticles = 7;
+        const pars = {
+            base: {n: 1, sd: 0},
+            name: "sd",
+            values: [0, 1, 10, 100]
+        };
+        const res = batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles);
+        expect(res.solutions.length).toBe(4);
+        expect(res.errors).toStrictEqual([]);
+        const traces0 = res.solutions[0](allTimes);
+        expect(traces0.x).toStrictEqual(seq(0, 100).map((x) => x * dt));
+        expect(traces0.values).toStrictEqual(
+            [{ name: "x", y: Array(101).fill(0) }]);
+        const traces1 = res.solutions[1](allTimes);
+        expect(traces1.values.length).toBe(1);
+        expect(traces1.values[0].name).toBe("x");
+        expect(traces1.values[0].y.slice(1).every((x) => x !== 0)).toBe(true);
+
+        const end = res.valueAtTime(10);
+        expect(end.x).toStrictEqual(pars.values);
+        expect(end.values.length).toBe(1);
+        expect(end.values[0].name).toBe("x");
+        expect(end.values[0].y).toStrictEqual(res.solutions.map((el) => el(allTimes).values[0].y[100]));
+
+        const max = res.extreme("yMax");
+        expect(max.x).toStrictEqual(pars.values);
+        expect(max.values.length).toBe(1);
+        expect(max.values[0].name).toBe("x");
+        expect(max.values[0].y).toStrictEqual(
+            res.solutions.map((el) => Math.max(...el(allTimes).values[0].y)));
+    });
+
+    it("can report on near miss values", () => {
+        const tEnd = 10;
+        const dt = 0.1;
+        const nParticles = 7;
+        const pars = {
+            base: {n: 1, sd: 0},
+            name: "sd",
+            values: [0, 1, 10, 100]
+        };
+        const res = batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles);
+        const end = res.valueAtTime(9 + 1e-4);
+        expect(end.values[0].y).toStrictEqual(
+            res.solutions.map((el) => el(allTimes).values[0].y[90]));
+    });
+
+    it("can return a partial set of results on error", () => {
+        const tEnd = 10;
+        const dt = 0.1;
+        const nParticles = 7;
+        const pars = {
+            base: {n: 1, sd: 0},
+            name: "sd",
+            values: [-2, -1, 0, 1, 2]
+        };
+        const res = batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles);
+        expect(res.pars.values).toStrictEqual([0, 1, 2]);
+        expect(res.solutions.length).toBe(3);
+    });
+
+    it("can throw if all solutions fail", () => {
+        const tEnd = 10;
+        const dt = 0.1;
+        const nParticles = 7;
+        const pars = {
+            base: {n: 1, sd: 0},
+            name: "sd",
+            values: [-3, -2, -1]
+        };
+        expect(() => batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles))
+            .toThrow("All solutions failed; first error: Expected 'sd' to be at least 0");
     });
 });

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -151,6 +151,7 @@ describe("can run batch", () => {
             values: [0, 1, 10, 100]
         };
         const res = batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles);
+        res.run();
         expect(res.solutions.length).toBe(4);
         expect(res.errors).toStrictEqual([]);
         const traces0 = res.solutions[0](allTimes);
@@ -186,6 +187,7 @@ describe("can run batch", () => {
             values: [0, 1, 10, 100]
         };
         const res = batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles);
+        res.run();
         const end = res.valueAtTime(9 + 1e-4);
         expect(end.values[0].y).toStrictEqual(
             res.solutions.map((el) => el(allTimes).values[0].y[90]));
@@ -201,6 +203,7 @@ describe("can run batch", () => {
             values: [-2, -1, 0, 1, 2]
         };
         const res = batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles);
+        res.run();
         expect(res.pars.values).toStrictEqual([0, 1, 2]);
         expect(res.solutions.length).toBe(3);
     });
@@ -214,7 +217,8 @@ describe("can run batch", () => {
             name: "sd",
             values: [-3, -2, -1]
         };
-        expect(() => batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles))
+        const res = batchRunDiscrete(models.Walk, pars, 0, tEnd, dt, nParticles);
+        expect(() => res.run())
             .toThrow("All solutions failed; first error: Expected 'sd' to be at least 0");
     });
 });


### PR DESCRIPTION
~This will fail until https://github.com/mrc-ide/odin-js/pull/23 is merged and npm updated as I have no idea how to properly depend on in-development versions of packages. Confirmed working locally via some ugly hacks :)~

Batch runner for stochastic models - I've not exposed an immediate interface here at all, only the iterative one.

Fixes #10, which was an initial implementation, tests are copied over