### PR TITLE
Groundwork for extensible summaries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
     "name": "@reside-ic/dust",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/dust",
-            "version": "0.0.2",
+            "version": "0.0.3",
             "license": "MIT",
             "dependencies": {
-                "@reside-ic/odinjs": "^0.1.0",
+                "@reside-ic/odinjs": "^0.1.1",
                 "@reside-ic/random": "^0.0.3",
                 "ndarray": "^1.0.19"
             },
@@ -1105,9 +1105,9 @@
             }
         },
         "node_modules/@reside-ic/odinjs": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@reside-ic/odinjs/-/odinjs-0.1.0.tgz",
-            "integrity": "sha512-rLx2WIWszn4Pk9Q5bAMlZM89QcDNgBkCmjqdyPksqbp/vesezFDaC5YPQWOgKOeVl/9CwbHU5ImJvSTwM1zkJw==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@reside-ic/odinjs/-/odinjs-0.1.1.tgz",
+            "integrity": "sha512-83+qZvP3veMtizI2IjZaA6Gyfdbby80WZ7zlzL5SlCxHz2H1H2nkQFrALFVlrU1SdIsPw7dNL+6QNhCdbmnsUA==",
             "dependencies": {
                 "@reside-ic/interpolate": "^0.0.1",
                 "dfoptim": "^0.0.5",
@@ -6630,9 +6630,9 @@
             }
         },
         "@reside-ic/odinjs": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@reside-ic/odinjs/-/odinjs-0.1.0.tgz",
-            "integrity": "sha512-rLx2WIWszn4Pk9Q5bAMlZM89QcDNgBkCmjqdyPksqbp/vesezFDaC5YPQWOgKOeVl/9CwbHU5ImJvSTwM1zkJw==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@reside-ic/odinjs/-/odinjs-0.1.1.tgz",
+            "integrity": "sha512-83+qZvP3veMtizI2IjZaA6Gyfdbby80WZ7zlzL5SlCxHz2H1H2nkQFrALFVlrU1SdIsPw7dNL+6QNhCdbmnsUA==",
             "requires": {
                 "@reside-ic/interpolate": "^0.0.1",
                 "dfoptim": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/dust",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Dust-like interface for js",
     "main": "index.js",
     "scripts": {
@@ -38,7 +38,7 @@
         "webpack-cli": "^4.10.0"
     },
     "dependencies": {
-        "@reside-ic/odinjs": "^0.1.0",
+        "@reside-ic/odinjs": "^0.1.1",
         "@reside-ic/random": "^0.0.3",
         "ndarray": "^1.0.19"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,6 @@ export {
     DiscreteSeriesSet,
     DiscreteSeriesValues,
     FilteredDiscreteSolution,
+    SummaryRule,
     wodinRunDiscrete
 } from "./wodin";

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ export { dustStateTime, DustStateTime } from "./state-time";
 export { versions } from "./versions";
 export {
     batchRunDiscrete,
-    DiscreteSeriesMode,
     DiscreteSeriesSet,
     DiscreteSeriesValues,
     FilteredDiscreteSolution,

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -2,7 +2,7 @@
 export function versions() {
     return {
         random: "0.0.3",
-        odinjs: "0.1.0",
-        dust: "0.0.2",
+        odinjs: "0.1.1",
+        dust: "0.0.3",
     };
 }

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -263,15 +263,15 @@ export function batchRunDiscrete(Model: DustModelConstructable, pars: BatchPars,
                                  dt: number, nParticles: number,
                                  summary?: SummaryRule[]): Batch {
     const run = (p: UserType, t0: number, t1: number) =>
-        centralOnly(wodinRunDiscrete(Model, p, t0, t1, dt, nParticles, summary));
+        summaryOnly(wodinRunDiscrete(Model, p, t0, t1, dt, nParticles, summary));
     return new Batch(run, pars, timeStart, timeEnd);
 }
 
-export function centralOnly(solution: FilteredDiscreteSolution): InterpolatedSolution {
-    return (times: Times) => filterToCentralOnly(solution(times));
+export function summaryOnly(solution: FilteredDiscreteSolution): InterpolatedSolution {
+    return (times: Times) => filterToSummaryOnly(solution(times));
 }
 
-export function filterToCentralOnly(result: DiscreteSeriesSet): SeriesSet {
+export function filterToSummaryOnly(result: DiscreteSeriesSet): SeriesSet {
     const values = result.values
         .filter((el: DiscreteSeriesValues) => el.description !== "Individual");
     return {

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -254,9 +254,10 @@ export function tidyDiscreteSolutionVariable(name: string, solution: DiscreteSol
  */
 export function batchRunDiscrete(Model: DustModelConstructable, pars: BatchPars,
                                  timeStart: number, timeEnd: number,
-                                 dt: number, nParticles: number): Batch {
+                                 dt: number, nParticles: number,
+                                 summary?: SummaryRule[]): Batch {
     const run = (p: UserType, t0: number, t1: number) =>
-        centralOnly(wodinRunDiscrete(Model, p, t0, t1, dt, nParticles));
+        centralOnly(wodinRunDiscrete(Model, p, t0, t1, dt, nParticles, summary));
     return new Batch(run, pars, timeStart, timeEnd);
 }
 
@@ -266,8 +267,7 @@ export function centralOnly(solution: FilteredDiscreteSolution): InterpolatedSol
 
 export function filterToCentralOnly(result: DiscreteSeriesSet): SeriesSet {
     const values = result.values
-        .filter((el: DiscreteSeriesValues) => el.description !== "Individual")
-        .map((el: DiscreteSeriesValues) => ({ name: el.name, y: el.y }));
+        .filter((el: DiscreteSeriesValues) => el.description !== "Individual");
     return {
         x: result.x,
         values

--- a/src/wodin.ts
+++ b/src/wodin.ts
@@ -137,6 +137,9 @@ export function runModelDiscrete(Model: DustModelConstructable,
  * @param dt The size of each step
  *
  * @param nParticles The number of independent particles (replicates) to run
+ *
+ * @param summary An array of summary rules to apply over stochastic
+ * traces. Defaults to just the mean.
  */
 export function wodinRunDiscrete(Model: DustModelConstructable,
                                  pars: UserType, timeStart: number, timeEnd: number,
@@ -251,6 +254,9 @@ export function tidyDiscreteSolutionVariable(name: string, solution: DiscreteSol
  * @param dt The size of each step
  *
  * @param nParticles The number of independent particles (replicates) to run
+ *
+ * @param summary An array of summary rules to apply over stochastic
+ * traces. Defaults to just the mean.
  */
 export function batchRunDiscrete(Model: DustModelConstructable, pars: BatchPars,
                                  timeStart: number, timeEnd: number,

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,7 +1,7 @@
 import { Times, TimeMode } from "@reside-ic/odinjs";
 
 import { dustStateTime } from "../src/state-time";
-import { mean, meanArray, seq, seqBy } from "../src/util";
+import { applyArray, mean, meanArray, seq, seqBy } from "../src/util";
 import {
     batchRunDiscrete,
     filterIndex,
@@ -32,6 +32,28 @@ describe("wodin interface", () => {
             .toStrictEqual(rep("x", 4));
         const y = res.values.map((s) => s.y);
         expect(meanArray(y.slice(0, 3))).toStrictEqual(y[3]);
+    });
+
+    it("can customise the summary", () => {
+        const pars = { n: 1, sd: 3 };
+        const min = (x: number[]) => Math.min(...x);
+        const max = (x: number[]) => Math.max(...x);
+        const summary = [
+            { description: "Min", summary: min },
+            { description: "Mean", summary: mean },
+            { description: "Max", summary: max }
+        ];
+        const sol = wodinRunDiscrete(models.Walk, pars, 0, 10, 1, 13, summary);
+        const res = sol(allTimes);
+        expect(res.x).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        expect(res.values.map((s) => s.description))
+            .toStrictEqual([...rep("Individual", 13), "Min", "Mean", "Max"]);
+        expect(res.values.map((s) => s.name))
+            .toStrictEqual(rep("x", 13 + 3));
+        const y = res.values.map((s) => s.y);
+        expect(applyArray(y.slice(0, 13), min)).toStrictEqual(y[13]);
+        expect(meanArray(y.slice(0, 13))).toStrictEqual(y[14]);
+        expect(applyArray(y.slice(0, 13), max)).toStrictEqual(y[15]);
     });
 
     it("simplifies deterministic traces", () => {

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -26,7 +26,7 @@ describe("wodin interface", () => {
         const sol = wodinRunDiscrete(models.Walk, pars, 0, 10, 1, 3);
         const res = sol(allTimes);
         expect(res.x).toStrictEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-        expect(res.values.map((s) => s.mode))
+        expect(res.values.map((s) => s.description))
             .toStrictEqual([...rep("Individual", 3), "Mean"]);
         expect(res.values.map((s) => s.name))
             .toStrictEqual(rep("x", 4));
@@ -39,7 +39,7 @@ describe("wodin interface", () => {
         const sol = wodinRunDiscrete(models.Walk, pars, 0, 10, 1, 7);
         expect(sol(allTimes)).toStrictEqual({
             x: seq(0, 10),
-            values: [{ mode: "Deterministic", name: "x", y: rep(0, 11) }]
+            values: [{ description: "Deterministic", name: "x", y: rep(0, 11) }]
         });
     });
 
@@ -48,7 +48,7 @@ describe("wodin interface", () => {
         const sol = wodinRunDiscrete(models.Walk, pars, 0, 10, 0.1, 7);
         expect(sol(allTimes)).toStrictEqual({
             x: seq(0, 100).map((s) => s * 0.1),
-            values: [{ mode: "Deterministic", name: "x", y: rep(0, 101) }]
+            values: [{ description: "Deterministic", name: "x", y: rep(0, 101) }]
         });
     });
 });
@@ -71,9 +71,9 @@ describe("summarise discrete model output", () => {
         expect(tidyDiscreteSolution(solution)).toStrictEqual({
             x: times,
             values: [
-                { mode: "Deterministic", name: "x", y: rep(0, 4) },
-                { mode: "Deterministic", name: "y", y: rep(0, 4) },
-                { mode: "Deterministic", name: "z", y: rep(0, 4) },
+                { description: "Deterministic", name: "x", y: rep(0, 4) },
+                { description: "Deterministic", name: "y", y: rep(0, 4) },
+                { description: "Deterministic", name: "z", y: rep(0, 4) },
             ]
         });
     });
@@ -84,14 +84,14 @@ describe("summarise discrete model output", () => {
         trace.set(2, 1);
         const res1 = tidyDiscreteSolutionVariable("y", solution);
         const y1 = {
-            mode: "Individual",
+            description: "Individual",
             name: "y",
             y: rep(0, 4)
         };
         const y2 = { ...y1, y: [0, 0, 1, 0] };
-        const y3 = { ...y1, y: [0, 0, 0.2, 0], mode: "Mean" };
-        const x = { mode: "Deterministic", name: "x", y: rep(0, 4) };
-        const z = { mode: "Deterministic", name: "z", y: rep(0, 4) };
+        const y3 = { ...y1, y: [0, 0, 0.2, 0], description: "Mean" };
+        const x = { description: "Deterministic", name: "x", y: rep(0, 4) };
+        const z = { description: "Deterministic", name: "z", y: rep(0, 4) };
         const expected = [y1, y1, y2, y1, y1, y3];
         expect(res1).toStrictEqual(expected);
         const res = tidyDiscreteSolution(solution);

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -1,7 +1,7 @@
 import { Times, TimeMode } from "@reside-ic/odinjs";
 
 import { dustStateTime } from "../src/state-time";
-import { meanArray, seq, seqBy } from "../src/util";
+import { mean, meanArray, seq, seqBy } from "../src/util";
 import {
     batchRunDiscrete,
     filterIndex,
@@ -65,10 +65,11 @@ describe("summarise discrete model output", () => {
         { dim: [1], length: 1, name: "z" }
     ];
     const solution = { info, state, times };
+    const summary = [{ description: "Mean", summary: mean }];
 
     it("can collapse entirely deterministic output", () => {
         data.fill(0);
-        expect(tidyDiscreteSolution(solution)).toStrictEqual({
+        expect(tidyDiscreteSolution(solution, summary)).toStrictEqual({
             x: times,
             values: [
                 { description: "Deterministic", name: "x", y: rep(0, 4) },
@@ -82,7 +83,7 @@ describe("summarise discrete model output", () => {
         data.fill(0);
         const trace = state.viewTrace(1, 2); // trace 1 (2nd), particle 2 (3rd)
         trace.set(2, 1);
-        const res1 = tidyDiscreteSolutionVariable("y", solution);
+        const res1 = tidyDiscreteSolutionVariable("y", solution, summary);
         const y1 = {
             description: "Individual",
             name: "y",
@@ -94,7 +95,7 @@ describe("summarise discrete model output", () => {
         const z = { description: "Deterministic", name: "z", y: rep(0, 4) };
         const expected = [y1, y1, y2, y1, y1, y3];
         expect(res1).toStrictEqual(expected);
-        const res = tidyDiscreteSolution(solution);
+        const res = tidyDiscreteSolution(solution, summary);
         expect(res).toEqual({
             x: times,
             values: [x, ...expected, z]

--- a/test/wodin.test.ts
+++ b/test/wodin.test.ts
@@ -248,7 +248,7 @@ describe("can run batch", () => {
             .toThrow("All solutions failed; first error: Expected 'sd' to be at least 0");
     });
 
-    it.only("can customise summary statistics", () => {
+    it("can customise summary statistics", () => {
         const min = (x: number[]) => Math.min(...x);
         const max = (x: number[]) => Math.max(...x);
         const summary = [
@@ -294,7 +294,6 @@ describe("can run batch", () => {
         // the different min/max types here somehow, probably an issue
         // in the summary code in odin....
         const end = res.valueAtTime(10);
-        console.log(end);
         expect(end.x).toStrictEqual(pars.values);
         expect(end.values.length).toBe(1);
         expect(end.values[0].name).toBe("x");


### PR DESCRIPTION
This will fail until https://github.com/mrc-ide/odin-js/pull/25 is merged and released to npm

* minor change in SeriesSetValues with `mode` moving from an enum to a string called `description` which happens to have some conventional values
* optional extra argument which preserves the existing behaviour of mean returned
* testing to make sure that processing of batch output is correct.
