### PR TITLE
Rexport batch parameter generation from odin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@reside-ic/dust",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@reside-ic/dust",
-            "version": "0.0.3",
+            "version": "0.0.4",
             "license": "MIT",
             "dependencies": {
                 "@reside-ic/odinjs": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@reside-ic/dust",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "description": "Dust-like interface for js",
     "main": "index.js",
     "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,3 +19,9 @@ export {
     SummaryRule,
     wodinRunDiscrete
 } from "./wodin";
+
+// We also need to rexport these:
+export {
+    batchParsDisplace,
+    batchParsRange
+} from "@reside-ic/odinjs"

--- a/src/versions.ts
+++ b/src/versions.ts
@@ -3,6 +3,6 @@ export function versions() {
     return {
         random: "0.0.3",
         odinjs: "0.1.1",
-        dust: "0.0.3",
+        dust: "0.0.4",
     };
 }


### PR DESCRIPTION
Makes `batchParsDisplace` and `batchParsRange` directly available from dust, which will simplify wodin a bit as it can use just the stochastic runner